### PR TITLE
Support a zoomable function with Ctrl and scroll on ERD Diagram for AmaterasERD

### DIFF
--- a/net.java.amateras.db/src/net/java/amateras/db/DBPlugin.java
+++ b/net.java.amateras.db/src/net/java/amateras/db/DBPlugin.java
@@ -47,6 +47,7 @@ public class DBPlugin extends AbstractUIPlugin {
 	public static final String PREF_GRID_SIZE = "pref_grid_size";
 	public static final String PREF_SNAP_GEOMETRY = "pref_snap_geometry";
 	public static final String PREF_SHOW_NOT_NULL = "pref_show_notnull";
+	public static final String PREF_ZOOMABLE_WITH_CTRL_AND_SCROLL = "pref_zoomable_with_ctrl_and_scroll";
 	public static final String PREF_FONT = "pref_font";
 	public static final String PREF_DICTIONALY = "pref_dictionary";
 

--- a/net.java.amateras.db/src/net/java/amateras/db/DBPlugin.properties
+++ b/net.java.amateras.db/src/net/java/amateras/db/DBPlugin.properties
@@ -209,6 +209,7 @@ preference.layout=Layout
 preference.layout.showGrid=Show Grid
 preference.layout.gridSize=Grid Size
 preference.layout.snapToGeometry=Snap to Geometry
+preference.layout.zoomableWithCtrlAndScroll=Zoomable with CTRL + Scroll
 
 preference.diagram=Diagram
 preference.diagram.showNotNull=Show NOT NULL Constraint

--- a/net.java.amateras.db/src/net/java/amateras/db/DBPlugin_ja.properties
+++ b/net.java.amateras.db/src/net/java/amateras/db/DBPlugin_ja.properties
@@ -209,6 +209,7 @@ preference.layout=\u30ec\u30a4\u30a2\u30a6\u30c8
 preference.layout.showGrid=\u30b0\u30ea\u30c3\u30c9\u7dda\u3092\u8868\u793a
 preference.layout.gridSize=\u30b0\u30ea\u30c3\u30c9\u30b5\u30a4\u30ba
 preference.layout.snapToGeometry=\u4ed6\u306e\u56f3\u5f62\u306b\u30b9\u30ca\u30c3\u30d7
+preference.layout.zoomableWithCtrlAndScroll=CTRL+\u30B9\u30AF\u30ED\u30FC\u30EB\u3067\u62E1\u5927/\u7E2E\u5C0F\u304C\u53EF\u80FD
 
 preference.diagram=\u30c0\u30a4\u30a2\u30b0\u30e9\u30e0
 preference.diagram.showNotNull=NOT NULL\u5236\u7d04\u3092\u8868\u793a

--- a/net.java.amateras.db/src/net/java/amateras/db/preference/ERDPreferencePage.java
+++ b/net.java.amateras.db/src/net/java/amateras/db/preference/ERDPreferencePage.java
@@ -25,6 +25,8 @@ public class ERDPreferencePage extends PreferencePage implements IWorkbenchPrefe
 	
 	private BooleanFieldEditor showNotNull;
 
+	private BooleanFieldEditor zoomableWithCtrlAndScroll;
+
 	public void init(IWorkbench workbench) {
 	}
 
@@ -44,6 +46,11 @@ public class ERDPreferencePage extends PreferencePage implements IWorkbenchPrefe
 				layoutGroup);
 		snapToGeometry = new BooleanFieldEditor(DBPlugin.PREF_SNAP_GEOMETRY, DBPlugin.getResourceString(
 				"preference.layout.snapToGeometry"), layoutGroup);
+
+		zoomableWithCtrlAndScroll = new BooleanFieldEditor(DBPlugin.PREF_ZOOMABLE_WITH_CTRL_AND_SCROLL, DBPlugin.getResourceString(
+				"preference.layout.zoomableWithCtrlAndScroll"), layoutGroup);
+		zoomableWithCtrlAndScroll.fillIntoGrid(layoutGroup, 2);
+
 		layoutGroup.setLayout(new GridLayout(3, false));
 		
 		// for Diagram (Grid)
@@ -74,6 +81,9 @@ public class ERDPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		
 		showNotNull.setPreferenceStore(store);
 		showNotNull.load();
+
+		zoomableWithCtrlAndScroll.setPreferenceStore(store);
+		zoomableWithCtrlAndScroll.load();
 	}
 	
 	public boolean performOk() {
@@ -81,6 +91,7 @@ public class ERDPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		gridSize.store();
 		snapToGeometry.store();
 		showNotNull.store();
+		zoomableWithCtrlAndScroll.store();
 		return true;
 	}
 

--- a/net.java.amateras.db/src/net/java/amateras/db/visual/editor/VisualDBEditor.java
+++ b/net.java.amateras.db/src/net/java/amateras/db/visual/editor/VisualDBEditor.java
@@ -51,6 +51,8 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.MouseWheelHandler;
+import org.eclipse.gef.MouseWheelZoomHandler;
 import org.eclipse.gef.SnapToGeometry;
 import org.eclipse.gef.SnapToGrid;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
@@ -490,6 +492,15 @@ public class VisualDBEditor extends GraphicalEditorWithPalette
 
 		getGraphicalViewer().setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED,
 		                new Boolean(store.getBoolean(DBPlugin.PREF_SNAP_GEOMETRY)));
+
+		boolean isZoomableWithCtrlAndScroll = store.getBoolean(DBPlugin.PREF_ZOOMABLE_WITH_CTRL_AND_SCROLL);
+		String mouseWheelHandlerKey = MouseWheelHandler.KeyGenerator.getKey(SWT.CTRL);
+		if (isZoomableWithCtrlAndScroll) {
+			getGraphicalViewer().setProperty(mouseWheelHandlerKey,
+					MouseWheelZoomHandler.SINGLETON);
+		} else {
+			getGraphicalViewer().setProperty(mouseWheelHandlerKey, null);
+		}
 	}
 
 	public void propertyChange(PropertyChangeEvent evt) {


### PR DESCRIPTION
* AmaterasERD의 Visual DB Editor에서 Table이 많을 경우, 사용자가 에디터 확대/축소하여 한 눈에 보기 쉽도록 제공하는 기능을 추가하였습니다.
* 사용 방법은 아래와 같습니다.
  - eGov > Window > Preferences > AmaterasERD > Layout에서 [**Zoomable with CTRL + Scroll**] 체크를 합니다.
![image](https://user-images.githubusercontent.com/3443879/127544143-fc306653-c1dc-49de-a23b-3575fcc0c1b2.png)
  - **ER Diagram Editor**(or **VisualDBEditor**)에서 **Ctrl + Scroll** 을 이용해 Zoom In/out을 사용할 수 있게 됩니다.
