### PR TITLE
DBIO Search View에서 열려진 프로젝트(Open project) 목록만 표시되게 수정

### DIFF
--- a/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/search/QueryIdSearchView.java
+++ b/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/search/QueryIdSearchView.java
@@ -17,18 +17,24 @@ package egovframework.dev.imp.dbio.search;
 
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TreeNodeContentProvider;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -115,20 +121,44 @@ public class QueryIdSearchView extends ViewPart implements SearchQueryId{
 		Label label = new Label(composite, SWT.NONE);
 		label.setText("Project:");
 		
+		GridData gd = new GridData();
+		gd.widthHint = 300;
+
 		projectViewer = new ComboViewer(composite, SWT.READ_ONLY | SWT.DROP_DOWN);
 		projectViewer.setContentProvider(new WorkbenchContentProvider());
 		projectViewer.setLabelProvider(new WorkbenchLabelProvider());
 		projectViewer.setInput(ResourcesPlugin.getWorkspace().getRoot());
+
 		projectViewer.addSelectionChangedListener(new ISelectionChangedListener() {
 			public void selectionChanged(SelectionChangedEvent event) {
 				toggleSearchButton();
 			}
 		});
+		projectViewer.getCombo().setLayoutData(gd);
+		projectViewer.getCombo().addFocusListener(new FocusAdapter() {
+			@Override
+			public void focusGained(FocusEvent e) {
+				refreshProjectsList();
+			}
+		});
+		projectViewer.setFilters(new ViewerFilter() {
+			@Override
+			public boolean select(Viewer viewer, Object parentElement, Object element) {
+				if (element instanceof IProject) {
+					IProject project = (IProject) element;
+					if (!project.isOpen()) {
+						return false;
+					}
+				}
+				return true;
+			}
+		});
+
 		label = new Label(composite, SWT.NONE);
 		label.setText("Query ID:");
 
 		queryInput = new Text(composite, SWT.BORDER);
-		GridData gd = new GridData();
+		gd = new GridData();
 		gd.widthHint = 200;
 		queryInput.setLayoutData(gd);
 		queryInput.addModifyListener(new ModifyListener() {
@@ -164,6 +194,13 @@ public class QueryIdSearchView extends ViewPart implements SearchQueryId{
 		}
 		
 		searchButton.setEnabled(true);
+	}
+
+	/**
+	 * 프로젝트 리스트 새로고침
+	 */
+	private void refreshProjectsList() {
+		projectViewer.refresh();
 	}
 
 	protected void openEditor(Object obj) {
@@ -253,3 +290,4 @@ public class QueryIdSearchView extends ViewPart implements SearchQueryId{
 		
 	}
 }
+


### PR DESCRIPTION
설명
---
* DBIO Search View의 프로젝트 리스트에는 닫혀진 프로젝트와 열린 프로젝트 모두 표시되고 있다.
* 사용자가 DBIO Search View에서 닫혀진 프로젝트(Closed project)를 선택 > Query ID 입력 후 Search 버튼을 누르게 되면 다음과 같은 오류(Problem occured)가 발생한다.
![Image](https://user-images.githubusercontent.com/3443879/181933701-8e413e9d-6120-45cc-9bb7-1245cc4dea97.png)

제안
---
* DBIO Search view의 프로젝트 선택 목록에는 닫혀진 프로젝트(Closed projects) 목록은 제외하며 열린 프로젝트(Open Projects) 목록만 나오도록 수정이 필요하다.

변경 코드 내용
---
* ViewerFilter를 통해 Package Explorer 에서 open 된 프로젝트만 Combo에 보일 수 있도록 변경함
* FocusListener 를 통해 Package Project 에서 사용자가 close 또는 open Project 하였을 경우, Project List 새로고침 작업함(refreshProjectList)
* 추가 사항 : Project List Combo Component 크기 300으로 지정 (GridData width : 300) : Package Explorer에 아무 프로젝트가 없을 경우 또는 모든 프로젝트가 닫혀진 프로젝트 (Closed Projects)인 경우, Component shrink 현상 발생하여 수정함