### PR TITLE
eGovBatch 설정 시 필요한 정보 확인을 위해 Dialog resizable로 변경

### DIFF
--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/JobRWDialog.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/JobRWDialog.java
@@ -463,4 +463,9 @@ abstract public class JobRWDialog extends StatusDialog {
 		
 		super.okPressed();
 	}
+
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }

--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/ListenerDialog.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/ListenerDialog.java
@@ -329,4 +329,8 @@ public class ListenerDialog extends StatusDialog {
 		return infos;
 	}
 
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/listeners/ListenerDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/listeners/ListenerDialog.java
@@ -356,4 +356,8 @@ public class ListenerDialog extends StatusDialog {
 		return listener;
 	}
 
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/parameter/JobParameterDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/parameter/JobParameterDialog.java
@@ -459,4 +459,9 @@ public class JobParameterDialog extends StatusDialog {
 	protected Point getInitialSize() {
 		return new Point(380, 265);
 	}
+
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/JobRWDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/JobRWDialog.java
@@ -463,4 +463,8 @@ public class JobRWDialog extends StatusDialog {
 		return new Point(380, 250);
 	}
 
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }

--- a/egovframework.bdev.tst/src/egovframework/bdev/tst/wizards/pages/GenerateFileDialog.java
+++ b/egovframework.bdev.tst/src/egovframework/bdev/tst/wizards/pages/GenerateFileDialog.java
@@ -371,4 +371,8 @@ public class GenerateFileDialog extends StatusDialog {
 		}
 	};
 
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }


### PR DESCRIPTION
설명
---
* eGovBatch 기능 설정 시 윈도우 기본폰트가 100%를 초과하는 경우, (eGovBatch 설정 생성, 변경 시) 배치 설정 Dialog 안에 설정 정보가 잘려보일 수 있다.
* (추가) 아래는 화면 첨부 파일이며, 해당 Dialog의 크기 변경을 할 수 없다.
![image](https://user-images.githubusercontent.com/3443879/182095136-9e8bada5-c946-42d3-9027-bd10f86ea8c8.png)

제안
---
* 배치 설정 시 필요한 정보 확인을 위해 Dialog 크기 조정 (Resizable) 가능하도록 수정이 필요하다.

변경 내용
---
* Dialog resizable 반영되는 항목은 아래와 같다.


**Preferences > eGovFrame > Batch**
```
Job Parameter : JobParameterDialog
Job Reader/Writer : JobRWDialog (Reader, Writer)
Listener : ListenerDialog (Job, Step, Chunk) 
```

**Menu > eGovFrame > Test > Batch Job Test > Customize Batch Job Test Option Wizard** 
```
Generate Batch Test File Dialog : GenerateFileDialog
```