### PR TITLE
baseOn 값(패키지명) 변경

### DIFF
--- a/net.java.amateras.db/schema/dialects.exsd
+++ b/net.java.amateras.db/schema/dialects.exsd
@@ -57,7 +57,7 @@
                   
                </documentation>
                <appInfo>
-                  <meta.attribute kind="java" basedOn="net.java.amateras.db.view.dialect.IDialect"/>
+                  <meta.attribute kind="java" basedOn="net.java.amateras.db.dialect.IDialect"/>
                </appInfo>
             </annotation>
          </attribute>


### PR DESCRIPTION
설명
---
* AmaterasERD plugin에서 정의한 확장점 설정(Class attribute의 type 설정)이 잘못되어 있음
* net.java.amateras.db.view.dialect.IDialect 인터페이스가 존재하지 않음

제안
---
* net.java.amateras.db.dialect.IDialect 인터페이스로 변경이 필요함

추가정보
---
* 해당 PR은 Amateras-modeler project의 Maintainer인 Takezoe가 Review 후 원본 소스에 반영(Merge) 하였음 (제안자 : @win777)
* 참조 : https://github.com/takezoe/amateras-modeler/pull/18

