### PR TITLE
[AmaterasERD] [새 데이터베이스 다이어그램] WizardPage의 "데이터베이스에서 테이블 가져오기" 단계에서 "Load Tables" 버튼을 클릭하면 테이블 목록에서 스크롤바가 사라지는 현상

### DIFF
--- a/net.java.amateras.db/src/net/java/amateras/db/wizard/NewDiagramWizardPage2.java
+++ b/net.java.amateras.db/src/net/java/amateras/db/wizard/NewDiagramWizardPage2.java
@@ -195,7 +195,7 @@ public class NewDiagramWizardPage2 extends WizardPage {
 		//----------------
 		UIUtils.createLabel(container, DBPlugin.getResourceString("wizard.new.import.tables"));
 		list = new List(container, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
-		list.setLayoutData(UIUtils.createGridData(3));
+		list.setLayoutData(UIUtils.createGridData(3, GridData.FILL_BOTH));
 		
 		//----------------
 		autoConvert = new Button(container, SWT.CHECK);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
* [새 데이터베이스 다이어그램 WizardPage]의 "데이터베이스에서 테이블 가져오기" 단계에서 "Load Tables" 버튼 클릭 시(테이블이 많이 있을 경우) 테이블 목록의 스크롤바와 "물리적 이름을 논리적 이름으로 변환" 버튼이 사라집니다. 
따라서, 사용자가 선택하고 싶은 테이블을 찾지 못할 수도 있습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [　] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video
**Screenshots (AS-IS)**
-

* Step 1. "Load tables" 버튼 클릭한다.
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/59d93759-e686-45f8-a620-08dc22cb482a)
스크롤바와 "Convert physical name to logical name" 버튼 사라짐

* Step 2. "최대화" 버튼 클릭한다.
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/b88c7abb-1bc0-4bf6-9486-f9c0d6b60601)

* Step 3. 테이블 표시하는 리스트에 스크롤바 사라짐, "물리적 이름을 논리적 이름으로 변환" 버튼 사라짐

**Screenshots (TO-BE)**
-

* Step 1. "Load tables" 버튼 클릭한다.
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/18dd4354-65ab-4e1a-a94b-19ec40e545ce)

* Step 2. "최대화" 버튼 클릭한다.
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/61ffec50-bf74-40d3-bfd9-a10f1d695947)

* Step 3. "최대화" 버튼 한 번 더 클릭한다.
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/18dd4354-65ab-4e1a-a94b-19ec40e545ce)

* Step 4. 테이블 표시하는 리스트에 스크롤바 보임, "물리적 이름을 논리적 이름으로 변환" 버튼 보임

참고사항
-
AmaterasModeler Repository에도 동일한 Pull Request 함. 추후, Merge 시 원작자의 Reivew 참고 바랍니다.
(https://github.com/takezoe/amateras-modeler/pull/25)