### PR TITLE
[BatchProjectCreationOperation] 이클립스 문제(Probems) 해결

### DIFF
--- a/egovframework.bdev.imp.ide/src/egovframework/bdev/imp/ide/com/wizards/operation/BatchProjectCreationOperation.java
+++ b/egovframework.bdev.imp.ide/src/egovframework/bdev/imp/ide/com/wizards/operation/BatchProjectCreationOperation.java
@@ -317,12 +317,12 @@ public abstract class BatchProjectCreationOperation implements IRunnableWithProg
 	// assignClasspathEntryToJavaProject(PreferenceConstants.getDefaultJRELibrary());
 	// }
 
-	/**
-	 * 스프링 네이처 추가
-	 */
-	private void createSpringNature(IProgressMonitor monitor) throws CoreException {
-		BatchIdeUtils.addNatureToProject(getProject(), "org.springframework.ide.eclipse.core.springnature", monitor);
-	}
+//	/**
+//	 * 스프링 네이처 추가
+//	 */
+//	private void createSpringNature(IProgressMonitor monitor) throws CoreException {
+//		BatchIdeUtils.addNatureToProject(getProject(), "org.springframework.ide.eclipse.core.springnature", monitor);
+//	}
 
 	/**
 	 * eGovFramework 네이처 추가


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [BatchProjectCreationOperation] 이클립스 문제(Probems) 해결

- The method createSpringNature(IProgressMonitor) from the type BatchProjectCreationOperation is never used locally
- `BatchProjectCreationOperation 유형의 createSpringNature(IProgressMonitor) 메소드는 로컬로 사용되지 않습니다.` 주석함


브랜치 생성
```
2024/probems/BatchProjectCreationOperation
```

The method createSpringNature(IProgressMonitor) from the type BatchProjectCreationOperation is never used locally	BatchProjectCreationOperation.java	/egovframework.bdev.imp.ide/src/egovframework/bdev/imp/ide/com/wizards/operation	line 323	Java Problem
```java
//	/**
//	 * 스프링 네이처 추가
//	 */
//	private void createSpringNature(IProgressMonitor monitor) throws CoreException {
//		BatchIdeUtils.addNatureToProject(getProject(), "org.springframework.ide.eclipse.core.springnature", monitor);
//	}
```

[2024년 전자정부 표준프레임워크 컨트리뷰션][개발환경][BatchProjectCreationOperation] 이클립스 문제(Probems) 해결

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/eOAB3XApUOk
