### PR TITLE
타입 변환 방식 개선: 생성자 대신 valueOf 사용

### DIFF
--- a/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/editor/parts/SqlMapQueryDetailsPart.java
+++ b/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/editor/parts/SqlMapQueryDetailsPart.java
@@ -611,20 +611,21 @@ public class SqlMapQueryDetailsPart extends AbstractDetailsPage implements Liste
 				sbp = (SqlBindingParm) tblItm[i].getData();
 				dataTypeIdx = ((Integer) sbp.dataTypeComboBox.getValue()).intValue();
 
-				if ("String".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
+				if ("String".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
 					parm.put(sbp.parm, sbp.value);
-				else if ("Byte".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
-					parm.put(sbp.parm, new Byte(sbp.value));
-				else if ("Integer".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
-					parm.put(sbp.parm, new Integer(sbp.value));
-				else if ("Long".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
-					parm.put(sbp.parm, new Long(sbp.value));
-				else if ("Float".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
-					parm.put(sbp.parm, new Float(sbp.value));
-				else if ("Double".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
-					parm.put(sbp.parm, new Double(sbp.value));
-				else if ("BigDecimal".equals(SqlBindingParm.dataTypes[dataTypeIdx]))
+				} else if ("Byte".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
+					parm.put(sbp.parm, Byte.valueOf(sbp.value));
+				} else if ("Integer".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
+					parm.put(sbp.parm, Integer.valueOf(sbp.value));
+				} else if ("Long".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
+					parm.put(sbp.parm, Long.valueOf(sbp.value));
+				} else if ("Float".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
+					parm.put(sbp.parm, Float.valueOf(sbp.value));
+				} else if ("Double".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
+					parm.put(sbp.parm, Double.valueOf(sbp.value));
+				} else if ("BigDecimal".equals(SqlBindingParm.dataTypes[dataTypeIdx])) {
 					parm.put(sbp.parm, new BigDecimal(sbp.value));
+				}
 			}
 
 			TestManager tm = new TestManager();


### PR DESCRIPTION
## 수정 사유 (Reason for modification)

소스를 수정한 사유가 무엇인지 체크해 주세요. (Please check the reason you modified the source.) ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 (Modified source)
* Deprecated 생성자 사용 제거: valueOf로 모든 숫자 타입 값 변환하였습니다.
* 향후 Deprecated 예상되어 코드 변경하였습니다.

**AS-IS**
<img width="977" height="462" alt="image" src="https://github.com/user-attachments/assets/e948b041-1e78-4724-a0dc-070e84603d4a" />

**TO-BE**
<img width="1043" height="488" alt="image" src="https://github.com/user-attachments/assets/6108a4a6-ac42-41a3-826c-c27747d3be26" />


※ BigDecimal은 Text 인자를 valueOf를 통해 받지 않으므로 기존 방식 그대로 유지하였습니다.