### PR TITLE
CRUD 코드 생성 템플릿의 하드코딩 주석 엔티티명 변수화 (Render entity names in CRUD comments)

### DIFF
--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/EgovSample2Service.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/EgovSample2Service.vm
@@ -38,7 +38,7 @@ import ${voPackage}.${voClassName};
 public interface $serviceClassName {
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 $voClassName
 	 * @return 등록 결과
 	 * @exception Exception
@@ -46,7 +46,7 @@ public interface $serviceClassName {
 	void $insertMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 $voClassName
 	 * @return void형
 	 * @exception Exception
@@ -54,7 +54,7 @@ public interface $serviceClassName {
 	void $updateMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 $voClassName
 	 * @return void형
 	 * @exception Exception
@@ -62,25 +62,25 @@ public interface $serviceClassName {
 	void $deleteMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 $voClassName
-	 * @return 조회한 글
+	 * @return 조회한 ${model.entity.name}
 	 * @exception Exception
 	 */
 	$voClassName $selectMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	List<?> $selectListMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글 총 갯수를 조회한다.
+	 * ${model.entity.name} 총 갯수를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 총 갯수
+	 * @return ${model.entity.name} 총 갯수
 	 * @exception
 	 */
 	int $selectListTotCntMethodName($voClassName vo);

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/EgovSample2ServiceImpl.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/EgovSample2ServiceImpl.vm
@@ -72,7 +72,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	private EgovIdGnrService egovIdGnrService;
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 ${voClassName}
 	 * @return 등록 결과
 	 * @exception Exception
@@ -95,7 +95,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -106,7 +106,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -117,9 +117,9 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 ${voClassName}
-	 * @return 조회한 글
+	 * @return 조회한 ${model.entity.name}
 	 * @exception Exception
 	 */
 	@Override
@@ -131,9 +131,9 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	@Override
@@ -142,9 +142,9 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글 총 갯수를 조회한다.
+	 * ${model.entity.name} 총 갯수를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 총 갯수
+	 * @return ${model.entity.name} 총 갯수
 	 * @exception
 	 */
 	@Override

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/Sample2Mapper.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/Sample2Mapper.vm
@@ -41,7 +41,7 @@ import ${voPackage}.${voClassName};
 public interface ${mapperClassName} {
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 ${voClassName}
 	 * @return 등록 결과
 	 * @exception Exception
@@ -49,7 +49,7 @@ public interface ${mapperClassName} {
 	void ${insertMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -57,7 +57,7 @@ public interface ${mapperClassName} {
 	void ${updateMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -65,25 +65,25 @@ public interface ${mapperClassName} {
 	void ${deleteMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 ${voClassName}
-	 * @return 조회한 글
+	 * @return 조회한 ${model.entity.name}
 	 * @exception Exception
 	 */
 	${voClassName} ${selectMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	List<?> ${selectListMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글 총 갯수를 조회한다.
+	 * ${model.entity.name} 총 갯수를 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 총 갯수
+	 * @return ${model.entity.name} 총 갯수
 	 * @exception
 	 */
 	int ${selectListTotCntMethodName}(${voClassName} vo);

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/web/EgovSample2Controller.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/web/EgovSample2Controller.vm
@@ -87,7 +87,7 @@ public class ${controllerClassName} {
 	private EgovPropertyService propertiesService;
 
 	/**
-	 * 글 목록을 조회한다. (pageing)
+	 * ${model.entity.name} 목록을 조회한다. (pageing)
 	 * @param ${voInstanceName} - 조회할 정보가 담긴 ${voClassName}
 	 * @param model
 	 * @return "${listView}"
@@ -125,7 +125,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글 등록 화면을 조회한다.
+	 * ${model.entity.name} 등록 화면을 조회한다.
 	 * @param ${voInstanceName} - 목록 조회조건 정보가 담긴 VO
 	 * @param model
 	 * @return "${registerView}"
@@ -140,7 +140,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param ${voInstanceName} - 등록할 정보가 담긴 VO
 	 * @param bindingResult
 	 * @param model
@@ -163,12 +163,12 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글 수정화면을 조회한다.
+	 * ${model.entity.name} 수정화면을 조회한다.
 #if(${model.primaryKeys} == [])
-	 * @param ${model.attributes.get(0).ccName} - 수정할 글 ${model.attributes.get(0).ccName}
+	 * @param ${model.attributes.get(0).ccName} - 수정할 ${model.entity.name} ${model.attributes.get(0).ccName}
 #else
 #foreach($attribute in $model.primaryKeys)
-	 * @param ${attribute.ccName} - 수정할 글 ${attribute.ccName}
+	 * @param ${attribute.ccName} - 수정할 ${model.entity.name} ${attribute.ccName}
 #end
 #end
 	 * @param model
@@ -189,7 +189,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param ${voInstanceName} - 수정할 정보가 담긴 VO
 	 * @param bindingResult
 	 * @param model
@@ -216,7 +216,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param ${voInstanceName} - 삭제할 정보가 담긴 VO
 	 * @param model
 	 * @param status

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/jsp/pkg/egovSample2List.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/jsp/pkg/egovSample2List.vm
@@ -66,7 +66,7 @@
 
 	<script type="text/javaScript" language="javascript" defer="defer">
 	<!--
-		/* 글 수정 화면 function */
+		/* ${model.entity.name} 수정 화면 function */
 		function fn_egov_select(${params}) {
 #if(${model.primaryKeys} == [])
 			document.listForm.${model.attributes.get(0).ccName}.value = ${model.attributes.get(0).ccName};
@@ -79,13 +79,13 @@
 			document.listForm.submit();
 		}
 
-		/* 글 등록 화면 function */
+		/* ${model.entity.name} 등록 화면 function */
 		function fn_egov_addView() {
 			document.listForm.action = "<c:url value='${addViewPath}'/>";
 			document.listForm.submit();
 		}
 
-		/* 글 목록 화면 function */
+		/* ${model.entity.name} 목록 화면 function */
 		function fn_egov_selectList() {
 			if(document.listForm.searchKeyword.value == '') {
 				alert("검색어를 입력해주세요.");


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

[#135](https://github.com/eGovFramework/egovframe-development/issues/135)에서 기여 정본으로 확인된 `egovframework.dev.imp.codegen.template.templates`의 CRUD 생성 주석을 수정합니다.

활성 템플릿은 선택한 엔티티와 관계없이 "글을 등록한다"와 같은 고정 주석을 생성합니다. 전수 확인 결과 5개 템플릿에 38곳이 있습니다.

- Service: 9
- ServiceImpl: 9
- Mapper: 9
- Controller: 8
- JSP list: 3

38곳의 하드코딩된 "글"을 `${model.entity.name}`으로 변경했습니다.

변경된 76개 diff 줄은 모두 주석입니다. Java 코드, SQL, 메서드 시그니처, Velocity 제어 흐름, JSP 동작은 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 검증 결과 Validation results

- `git diff --check` 통과
- 활성 CRUD 템플릿의 하드코딩된 `글` 0건 확인
- 추가·삭제된 76줄이 모두 주석임을 확인
- PK가 있는 `NOTICE_BOARD`와 PK가 없는 `MEMBER` 모델로 5개 템플릿 렌더
- Velocity JUnit: 1 test, 0 failures, 0 errors
- 검증 모듈 CI 등가 Maven package: BUILD SUCCESS

Controller 소스에는 치환이 8곳 있지만 PK 유무에 따른 두 `@param` 주석이 상호 배타적이므로 각 렌더 결과에는 엔티티명이 7곳 나타납니다.

Windows/Temurin JDK 17에서 CI 등가 Maven package는 성공했지만 레거시 검증 모듈에서 MS949 플랫폼 인코딩 진단이 출력됐습니다. 이 PR은 해당 모듈의 Java 소스를 변경하지 않으며, 별도 Velocity 렌더 assertion은 통과했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others — 브라우저 UI 변경 없음; Velocity 렌더 테스트로 검증

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

주석 전용 템플릿 변경으로 UI 스크린샷은 해당하지 않습니다. 위 렌더 테스트와 diff 불변 검증 결과를 첨부했습니다.
