### PR TITLE
docs(codegen): CRUD 템플릿 생성 주석의 엔티티명 변수화 복원

### DIFF
--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/EgovSample2Service.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/EgovSample2Service.vm
@@ -38,7 +38,7 @@ import ${voPackage}.${voClassName};
 public interface $serviceClassName {
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 $voClassName
 	 * @return 등록 결과
 	 * @exception Exception
@@ -46,7 +46,7 @@ public interface $serviceClassName {
 	void $insertMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 $voClassName
 	 * @return void형
 	 * @exception Exception
@@ -54,7 +54,7 @@ public interface $serviceClassName {
 	void $updateMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 $voClassName
 	 * @return void형
 	 * @exception Exception
@@ -62,7 +62,7 @@ public interface $serviceClassName {
 	void $deleteMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 $voClassName
 	 * @return 조회한 글
 	 * @exception Exception
@@ -70,9 +70,9 @@ public interface $serviceClassName {
 	$voClassName $selectMethodName($voClassName vo) throws Exception;
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	List<?> $selectListMethodName($voClassName vo) throws Exception;

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/EgovSample2ServiceImpl.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/EgovSample2ServiceImpl.vm
@@ -72,7 +72,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	private EgovIdGnrService egovIdGnrService;
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 ${voClassName}
 	 * @return 등록 결과
 	 * @exception Exception
@@ -95,7 +95,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -106,7 +106,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -117,7 +117,7 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 ${voClassName}
 	 * @return 조회한 글
 	 * @exception Exception
@@ -131,9 +131,9 @@ public class ${serviceImplClassName} extends EgovAbstractServiceImpl implements 
 	}
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	@Override

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/Sample2Mapper.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/service/impl/Sample2Mapper.vm
@@ -41,7 +41,7 @@ import ${voPackage}.${voClassName};
 public interface ${mapperClassName} {
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param vo - 등록할 정보가 담긴 ${voClassName}
 	 * @return 등록 결과
 	 * @exception Exception
@@ -49,7 +49,7 @@ public interface ${mapperClassName} {
 	void ${insertMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param vo - 수정할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -57,7 +57,7 @@ public interface ${mapperClassName} {
 	void ${updateMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param vo - 삭제할 정보가 담긴 ${voClassName}
 	 * @return void형
 	 * @exception Exception
@@ -65,7 +65,7 @@ public interface ${mapperClassName} {
 	void ${deleteMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글을 조회한다.
+	 * ${model.entity.name}을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 ${voClassName}
 	 * @return 조회한 글
 	 * @exception Exception
@@ -73,9 +73,9 @@ public interface ${mapperClassName} {
 	${voClassName} ${selectMethodName}(${voClassName} vo) throws Exception;
 
 	/**
-	 * 글 목록을 조회한다.
+	 * ${model.entity.name} 목록을 조회한다.
 	 * @param vo - 조회할 정보가 담긴 VO
-	 * @return 글 목록
+	 * @return ${model.entity.name} 목록
 	 * @exception Exception
 	 */
 	List<?> ${selectListMethodName}(${voClassName} vo) throws Exception;

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/web/EgovSample2Controller.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/pkg/web/EgovSample2Controller.vm
@@ -87,7 +87,7 @@ public class ${controllerClassName} {
 	private EgovPropertyService propertiesService;
 
 	/**
-	 * 글 목록을 조회한다. (pageing)
+	 * ${model.entity.name} 목록을 조회한다. (pageing)
 	 * @param ${voInstanceName} - 조회할 정보가 담긴 ${voClassName}
 	 * @param model
 	 * @return "${listView}"
@@ -125,7 +125,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글 등록 화면을 조회한다.
+	 * ${model.entity.name} 등록 화면을 조회한다.
 	 * @param ${voInstanceName} - 목록 조회조건 정보가 담긴 VO
 	 * @param model
 	 * @return "${registerView}"
@@ -140,7 +140,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 등록한다.
+	 * ${model.entity.name}을 등록한다.
 	 * @param ${voInstanceName} - 등록할 정보가 담긴 VO
 	 * @param bindingResult
 	 * @param model
@@ -163,7 +163,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글 수정화면을 조회한다.
+	 * ${model.entity.name} 수정화면을 조회한다.
 #if(${model.primaryKeys} == [])
 	 * @param ${model.attributes.get(0).ccName} - 수정할 글 ${model.attributes.get(0).ccName}
 #else
@@ -189,7 +189,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 수정한다.
+	 * ${model.entity.name}을 수정한다.
 	 * @param ${voInstanceName} - 수정할 정보가 담긴 VO
 	 * @param bindingResult
 	 * @param model
@@ -216,7 +216,7 @@ public class ${controllerClassName} {
 	}
 
 	/**
-	 * 글을 삭제한다.
+	 * ${model.entity.name}을 삭제한다.
 	 * @param ${voInstanceName} - 삭제할 정보가 담긴 VO
 	 * @param model
 	 * @param status


### PR DESCRIPTION
## 요약

CRUD 코드 생성 템플릿(crud/java)의 javadoc 주석이 엔티티와 무관하게 "글을 등록한다"로 하드코딩되어 있어, 어떤 엔티티로 생성해도 주석이 전부 "글" 기준으로 출력됩니다. `${model.entity.name}` 기반 표기로 복원합니다. 코드 영역은 변경하지 않습니다.

## 문제 (재현)

- `egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/crud/java/` 하위 4개 템플릿의 javadoc 주석 24곳이 "글을 등록한다/수정한다/삭제한다/조회한다", "글 목록…" 등으로 고정되어 있습니다.
- 예: 엔티티명 "회원"으로 생성해도 `MemberService.java`의 주석은 `* 글을 등록한다.`
- #135 답변에 따라 검증/테스트용 트리(`egovframework.dev.imp.templates`)를 비교한 결과, 같은 자리들이 `${model.entity.name}` 변수화로 남아 있습니다. 과거 표기가 이후 개편 과정에서 하드코딩으로 되돌아간 것으로 보여, 그 표기를 복원하는 취지입니다. 의도된 변경이었다면 알려주시면 따르겠습니다.

## 수정

- EgovSample2Service.vm / EgovSample2ServiceImpl.vm / Sample2Mapper.vm / EgovSample2Controller.vm 의 주석 24곳 (+24/−24, 주석 라인만)
- `글을 등록한다.` → `${model.entity.name}을 등록한다.`, `글 목록을 조회한다` → `${model.entity.name} 목록을 조회한다`, `@return 글 목록` → `@return ${model.entity.name} 목록` 등
- 조사(을/를) 고정은 기존 표기를 따랐습니다. `을(를)` 표기를 선호하시면 반영하겠습니다.

## 검증 (실측)

- Velocity 2.3 렌더 스모크: 수정 전/후 템플릿을 동일 컨텍스트로 렌더링해 생성물 비교 — 엔티티 2종(회원/Member, 부서코드/DeptCode) × 4템플릿 = 8쌍
- **비주석 diff 0라인**, 변경은 주석 48라인(24곳×2종)뿐 — 메서드 선언부 해시 동일 확인
- 예: `* 글을 등록한다.` → `* 회원을 등록한다.` / `* 부서코드 목록을 조회한다. (pageing)`

## 영향 범위

- 생성 코드의 동작·시그니처 무변경(주석 텍스트만). CRUD 코드 생성 사용자의 생성물 주석 품질 개선
- jsp 템플릿의 JS 주석 3곳("글 수정 화면 function" 등)은 기존 변수화 전례가 없어 이번 범위에서 제외했습니다. 필요하시면 후속으로 처리하겠습니다.

Refs #135