### PR TITLE
XmlUtil의 XML 외부 엔티티(XXE) 취약점 수정

### DIFF
--- a/egovframework.dev.imp.core/src/egovframework/dev/imp/core/utils/XmlUtil.java
+++ b/egovframework.dev.imp.core/src/egovframework/dev/imp/core/utils/XmlUtil.java
@@ -69,7 +69,6 @@ public class XmlUtil {
             dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
             dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
             if (!validating) {
                 dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
                 dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/egovframework.dev.imp.core/src/egovframework/dev/imp/core/utils/XmlUtil.java
+++ b/egovframework.dev.imp.core/src/egovframework/dev/imp/core/utils/XmlUtil.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +48,35 @@ public class XmlUtil {
     static {
         factory.setValidating(false);
         vfactory.setValidating(true);
+        // XXE(XML External Entity) 취약점 방지
+        applyXxeProtection(factory, false);
+        applyXxeProtection(vfactory, true);
+    }
+
+    /**
+     * XXE(XML External Entity Injection, CWE-611) 취약점을 방지하기 위해
+     * 외부 엔티티 처리를 제한한다.
+     *
+     * 외부 일반/파라미터 엔티티를 차단하면 검증 여부와 무관하게 외부 엔티티를 통한
+     * 로컬 파일 읽기·SSRF를 막을 수 있다. 스키마 검증(validating=true)이 필요한
+     * 파서는 DTD 로딩을 유지해야 하므로 외부 엔티티 차단만 적용한다.
+     *
+     * @param dbf 보호를 적용할 DocumentBuilderFactory
+     * @param validating 검증 파서 여부(true면 DTD 로딩을 유지)
+     */
+    private static void applyXxeProtection(DocumentBuilderFactory dbf, boolean validating) {
+        try {
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+            if (!validating) {
+                dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            }
+        } catch (ParserConfigurationException e) {
+            // 특정 기능을 지원하지 않는 파서에서도 나머지 방어는 적용되도록 무시한다.
+        }
     }
 	
 	public static Node getRootNode(String filePath) throws Exception{
@@ -184,6 +214,7 @@ public class XmlUtil {
         Node parentsNode = componentList.item(0);
         
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        applyXxeProtection(factory, false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));
         Node node = doc.getDocumentElement();
@@ -202,6 +233,7 @@ public class XmlUtil {
         Node parentsNode = componentList.item(0);
         
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        applyXxeProtection(factory, false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));
         Node node = doc.getDocumentElement();
@@ -225,6 +257,7 @@ public class XmlUtil {
 	    Node parentsNode = componentList.item(0);
 	    
 	    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+	    applyXxeProtection(factory, false);
 	    DocumentBuilder builder = factory.newDocumentBuilder();
 	    Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));
 	    Node node = doc.getDocumentElement();


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes (보안 취약점, CWE-611 XXE)
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`XmlUtil`이 XML을 파싱할 때 `DocumentBuilderFactory`에 외부 엔티티 차단 설정을 하지 않아 **XXE(XML External Entity Injection, CWE-611)** 에 노출됩니다. 미방어 지점은 정적 팩토리 2개(45·46행)와 지역 인스턴스 3개(186·204·227행, 수정 전 기준)입니다.

`XmlUtil`은 이 저장소의 6개 플러그인에서 호출되며, 그중 `HandlePomXMLFileUtil`은 프로젝트의 `pom.xml`을 파싱합니다. 따라서 외부 엔티티가 포함된 XML(예: 악의적 `pom.xml`)이 든 프로젝트를 IDE로 열면 개발자 PC의 로컬 파일이 읽히거나 외부 URL 요청이 발생할 수 있습니다.

**수정 내용**

이 저장소는 이미 같은 방어 패턴을 갖고 있습니다 — `egovframework.dev.imp.commngt`의 `ComResourceUtils.java` 213행이 `setFeature` 계열로 외부 엔티티를 차단합니다. 이 PR은 그 패턴을 `XmlUtil`에 맞춰 넣는 것으로 새 규칙을 도입하지 않습니다.

`applyXxeProtection(DocumentBuilderFactory, boolean)` private 헬퍼를 추가하고 5개 파싱 지점에 적용했습니다(+33/−0). 외부 일반/파라미터 엔티티를 차단해 **검증 여부와 무관하게** XXE 파일 읽기를 막습니다. 스키마 검증용 `vfactory`(validating=true)는 DTD 로딩이 필요하므로 외부 엔티티 차단만 적용하고, 비검증 파서에는 외부 DTD 로딩 차단과 `FEATURE_SECURE_PROCESSING`까지 적용했습니다. 파서가 특정 기능을 미지원하면 `ParserConfigurationException`을 무시하고 나머지 방어를 적용합니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

**빌드**: 번들된 `lib/xalan.jar`를 클래스패스로 `javac` 단독 컴파일 성공(JDK 21, 오류 0).

**재현·검증** (수정 전/후 동일 하네스, JDK 21.0.10 — `applyXxeProtection`의 실제 로직을 복제해 실행). 공격 XML(`<!DOCTYPE r [ <!ENTITY xxe SYSTEM "file://…"> ]>`)로 로컬 파일 읽기를 시도:

| 파서 | 수정 전 | 수정 후 |
|---|---|---|
| 비검증(non-validating) | **파일 유출** `v=[TOP-SECRET-EGOV-2026]` | **차단** `v=[]` |
| 검증(validating) | **파일 유출** `v=[TOP-SECRET-EGOV-2026]` | **차단** `v=[]` |

정상 XML 회귀 확인(파싱은 계속 동작해야 함):

| 파서 | 수정 후 |
|---|---|
| 비검증 | `v=[정상데이터]` (정상) |
| 검증 | `v=[정상데이터]` (정상) |

수정 후 외부 엔티티는 빈 값으로 무력화되고, 정상 XML 파싱과 스키마 검증 경로는 그대로 동작합니다.

## 테스트 브라우저 Test Browser

- [X] 기타 Others — UI 변경 없음. XML 파서 설정만 수정했으며 위 하네스로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 변경이 없어 스크린샷은 해당하지 않습니다. 위 표의 실측값을 근거로 제시합니다.

---

**참고 — 같은 저장소의 동일 유형 (이 PR 범위 밖)**: 근본 원인이 같은 XXE 미방어 지점이 `dev/mdev ComResourceUtils`(각 2곳, 같은 파일의 다른 지점은 이미 방어됨), `NexusPropertyPage`, `QueryIdSearchJob`에도 있습니다. 이 PR은 호출자가 가장 많은 `XmlUtil` 한 파일로 범위를 한정했으며, 나머지도 동일 방식으로 후속 정리할 수 있습니다. 필요하시면 이 PR에 합치겠습니다.

## 병합된 보안 수정 선례 (참고)

같은 조직(eGovFramework)에서 제가 제출한 동일 성격의 보안 수정들이 최근 병합되었습니다 — egovframe-common-components #1134(뷰 이름 인젝션 Locale 우회), #1156(상위 경로 `..` 재생성 차단), #1163(팝업 URL 탭 문자 우회 차단). 본 PR 은 그 연장선에서 개발환경 쪽 XML 파서의 외부 엔티티 해석을 표준 권고(외부 DTD·엔티티 비활성화)대로 차단하는 것입니다.