### PR TITLE
fix(rte.rdt): pom 버전 프로퍼티 미해결 시 NullPointerException 수정

### DIFF
--- a/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/Version.java
+++ b/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/Version.java
@@ -124,9 +124,10 @@ public class Version extends PomString implements Comparable<Version> {
 		if (properties != null && StringHelper.isPropertyString(getContent())) {
 			String version = StringHelper.getProperty(getContent());
 			if (version != null && version.length()>0) {
-				if (properties.getValue(version) != null)
+				if (properties.getValue(version) != null) {
 					setPropertyVersion(true);
 					realVersion = properties.getValue(version).toString();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제 (재현)
`egovframework.rte.rdt.pom.unit.Version.setContent()` 에서 `if (properties.getValue(version) != null)` 에 중괄호가 없어, 바로 아래 `realVersion = properties.getValue(version).toString();` 이 **조건과 무관하게 항상 실행**됩니다. (들여쓰기상 두 줄 모두 if 안처럼 보이지만 실제로는 `setPropertyVersion(true);` 한 줄만 가드됩니다.)

따라서 dependency 의 `<version>` 이 **해당 pom 의 `<properties>` 에 정의되지 않은 프로퍼티**를 참조하면 `properties.getValue(version)` 이 `null` 을 반환하고 `null.toString()` 에서 **NullPointerException** 이 발생해 pom 파싱이 중단됩니다. 대표적으로 Maven 내장 프로퍼티 `${project.version}` (또는 부모 pom 에서 상속되는 버전 프로퍼티)는 로컬 `<properties>` 에 존재하지 않으므로 바로 재현됩니다.

호출 경로: `PomObject.setDependencies` → `new Dependency(e, properties)` → `new Version(e, properties)` → `setContent`. `<properties>` 블록이 있는 pom 이면 `properties` 가 non-null 로 전달되므로 흔한 표기에서 그대로 발생합니다.

## 수정 내용
`if (properties.getValue(version) != null)` 블록에 중괄호를 추가하여, 프로퍼티가 해결될 때만 `propertyVersion`/`realVersion` 을 갱신하도록 했습니다. 미해결 시에는 상단에서 설정한 기본값(`realVersion = getContent()` = 원본 `${...}` 문자열, `propertyVersion = false`)이 그대로 유지됩니다.

```diff
-				if (properties.getValue(version) != null)
-					setPropertyVersion(true);
-					realVersion = properties.getValue(version).toString();
+				if (properties.getValue(version) != null) {
+					setPropertyVersion(true);
+					realVersion = properties.getValue(version).toString();
+				}
```

## 검증 (실측)
저장소의 `egovframework.rte.rdt/lib/jdom.jar` 로 실제 소스(Version/PomString/PomElement/PomMap/StringHelper)를 컴파일하여 확인했습니다.

- **수정 전**: `<version>${project.version}</version>` + `project.version` 미정의 → **NullPointerException**
- **수정 후**
  - `${project.version}` (미해결): 예외 없음, `getRealVersion()` = `"${project.version}"`, `isPropertyVersion()` = `false`
  - `${egov.rte.version}` (해결, 회귀): `getRealVersion()` = `"4.3.0"`, `isPropertyVersion()` = `true`
  - `4.3.0` (리터럴, 회귀): `getRealVersion()` = `"4.3.0"`, `isPropertyVersion()` = `false`