### PR TITLE
fix(codegen.model): 연관관계 양방향 end 이름·타입이 반대편 end에서 잘못 복사되는 오타 수정

### DIFF
--- a/egovframework.dev.imp.codegen.model/src/egovframework/dev/imp/codegen/model/converter/NonEclipseModelConverter.java
+++ b/egovframework.dev.imp.codegen.model/src/egovframework/dev/imp/codegen/model/converter/NonEclipseModelConverter.java
@@ -770,7 +770,7 @@ public class NonEclipseModelConverter extends UMLModelConverter implements IConv
 			if (ownedEnd1.hasAttribute("name"))
 				attributeName1 = ownedEnd1.getAttribute("name");
 			if (ownedEnd2.hasAttribute("name"))
-				attributeName2 = ownedEnd1.getAttribute("name");
+				attributeName2 = ownedEnd2.getAttribute("name");
 			if (ownedEnd1.hasChildNodes()) {
 				String classifierXmiId = ((Element) ownedEnd1.getElementsByTagName("type").item(0)).getAttribute("xmi:idref");
 				classifier1 = (Classifier) xmiIdtoObjectMap.get(classifierXmiId);
@@ -846,7 +846,7 @@ public class NonEclipseModelConverter extends UMLModelConverter implements IConv
 						attributeName1 = CommonUtil.firstCharToLowerCase(classifier1.getName());
 				}
 				if (memberEnd2.hasAttribute("xmi:idref")) {
-					Element attElement2 = (Element) associationAttMap.get(memberEnd1.getAttribute("xmi:idref"));
+					Element attElement2 = (Element) associationAttMap.get(memberEnd2.getAttribute("xmi:idref"));
 					if (attElement2.hasAttribute("name")) {
 						attributeName2 = attElement2.getAttribute("name");
 					}

--- a/egovframework.dev.imp.codegen.model/src/egovframework/dev/imp/codegen/model/converter/UML2NonEclipseModelConverter.java
+++ b/egovframework.dev.imp.codegen.model/src/egovframework/dev/imp/codegen/model/converter/UML2NonEclipseModelConverter.java
@@ -1004,7 +1004,7 @@ public class UML2NonEclipseModelConverter  extends UMLModelConverter implements 
 				attributeName1 = ownedEnd1.getAttribute("name");
 
 			if (ownedEnd2.hasAttribute("name"))
-				attributeName2 = ownedEnd1.getAttribute("name");
+				attributeName2 = ownedEnd2.getAttribute("name");
 
 			if (ownedEnd1.hasChildNodes()){
 				String classifierXmiId = ((Element) ownedEnd1.getElementsByTagName("type").item(0)).getAttribute("xmi:idref");


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제
`egovframework.dev.imp.codegen.model.converter.NonEclipseModelConverter.convertAssociation()` 에서 연관관계(Association)의 **두 번째 end**를 만들 때, 가드는 두 번째 end를 검사하지만 값은 **첫 번째 end에서** 읽어오는 복붙 오타가 2곳 있습니다.

**1) 양방향(ownedEnd 2개) 분기 — line 773**
```java
if (ownedEnd2.hasAttribute("name"))
    attributeName2 = ownedEnd1.getAttribute("name");   // ownedEnd2 여야 함
```
**2) memberEnd 2개 분기 — line 849**
```java
if (memberEnd2.hasAttribute("xmi:idref")) {
    Element attElement2 = (Element) associationAttMap.get(memberEnd1.getAttribute("xmi:idref"));  // memberEnd2 여야 함
```

그 결과 두 번째 end 의 이름(memberEnd 분기에서는 타입까지)이 첫 번째 end 값으로 덮여, 생성되는 연관관계의 양 끝 property 이름이 같아지거나(bidirectional) 자기 자신을 가리키는 **자기참조 연관**으로 잘못 생성됩니다.

**대조 증거**: 동일 로직의 형제 변환기 `UML2NonEclipseModelConverter.convertAssociation()` 은 memberEnd 분기(line 1126)에서 `memberEnd2.getAttribute("xmi:idref")` 로 **올바르게** 구현돼 있어, 위 line 849 가 오타임이 확인됩니다.

## 수정 내용
- line 773: `ownedEnd1` -> `ownedEnd2`
- line 849: `memberEnd1` -> `memberEnd2`

## 검증 (실측)
실제 클래스는 EMF/UML2 의존으로 standalone 컴파일이 어려워, 결함 메서드의 해당 분기를 그대로 추출해 **JDK `org.w3c.dom` 으로 동일 XMI 를 파싱**하여 검증했습니다(UML2 `createAssociation` 싱크만 인자 기록용으로 스텁).

- memberEnd 2개 (Order.orders <-> Customer.customer)
  - 수정 전: `createAssociation` 인자 `[Order, orders, Order, orders]` — 자기참조로 붕괴
  - 수정 후: `[Order, orders, Customer, customer]`
- ownedEnd 2개 (Board.writer <-> Comment.comments)
  - 수정 전: `[Board, writer, Comment, writer]` — end2 이름이 "writer" 로 잘못
  - 수정 후: `[Board, writer, Comment, comments]`

## 참고
동일한 ownedEnd 복붙 오타가 형제 변환기 `UML2NonEclipseModelConverter.java`(line 1007)에도 존재합니다. 원하시면 이 PR 에 함께 반영하거나 별도로 정리하겠습니다.