### PR TITLE
fix(bdev.batch): 배치 Job XML 생성 마법사가 decision 처리 중 무한 루프에 빠지는 문제 수정

### DIFF
--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
@@ -511,7 +511,6 @@ public class CreateBatchJobXMLFileOperation {
 		if(decisionVOList != null && decisionVOList.size() > 0) {
 			int j = 0;
 			for (j = 0; j < decisionVOList.size(); j++) {
-				j =+ decisionDone;
 				if(decisionVOList.size() > j){
 					if(jobName.equals(decisionVOList.get(j).getJobName())){
 						// decision

--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
@@ -60,9 +60,6 @@ public class CreateBatchJobXMLFileOperation {
 	/** partitionMode의 Step 정보*/
 	private ArrayList<String> partitionModeStep = new ArrayList<String>(); 
 	
-	/** decisionVOList중 xml파일에 추가한 decision의 수*/
-	private int decisionDone = 0;
-	
 	/** project name **/
 	private String projectName = null;
 	
@@ -568,8 +565,6 @@ public class CreateBatchJobXMLFileOperation {
 							}
 							
 						}
-						
-						decisionDone++;
 					}
 				}
 			}//for-end


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제 (재현)
`CreateBatchJobXMLFileOperation.appendDecisionElement()` 의 반복문 첫 줄이 다음과 같습니다.

```java
for (j = 0; j < decisionVOList.size(); j++) {
    j =+ decisionDone;   // j += decisionDone 이 아니라 j = +decisionDone 으로 해석됨
```

`=+` 는 복합대입 연산자가 아니라 **대입 + 단항 플러스**이므로, 매 반복마다 `j` 가 `decisionDone` 값으로 되돌아갑니다. `decisionDone` 은 **현재 Job 에 속한** decision 을 실제로 출력했을 때만 증가하므로, 목록에서 다른 Job 의 decision 을 만나면 `j` 가 그 자리에 고정되어 반복문이 끝나지 않습니다. 마법사 Finish 시 IDE 가 응답하지 않게 됩니다.

재현 조건: `decisionVOList` 에 여러 Job 의 decision 이 함께 담기고, 현재 Job 의 decision 을 모두 처리한 뒤에도 뒤에 다른 Job 의 decision 이 2건 이상 남아 있는 경우(`decisionDone + 1 < decisionVOList.size()`).

- 예) Job A 에 decision 1건, Job B 에 decision 2건 → **Job A 처리 중 무한 루프**
- 예) Job A 에 decision 0건, Job B 에 decision 2건 → **Job A 처리 중 무한 루프**

반대로 **단일 Job 이 모든 decision 을 소유**하는 경우에는 `decisionDone` 이 인덱스와 함께 증가해 정상 종료되기 때문에, 이 결함이 지금까지 드러나지 않은 것으로 보입니다.

## 수정 내용
`j =+ decisionDone;` 한 줄을 제거했습니다. 반복문은 목록 전체를 순회하며 `jobName` 으로 필터링하는 형태가 되어, 같은 파일의 step 처리 반복문(`stepVOList` 를 `jobName` 으로 필터링)과 동일한 방식이 됩니다.

```diff
 for (j = 0; j < decisionVOList.size(); j++) {
-    j =+ decisionDone;
     if(decisionVOList.size() > j){
         if(jobName.equals(decisionVOList.get(j).getJobName())){
```

## 검증 (실측)
해당 반복문의 제어 흐름을 그대로 옮긴 standalone 하네스로, 수정 전/후를 동일 입력으로 비교했습니다(무한 루프는 반복 상한으로 판정, JDOM 출력 대신 `decider{index}:{name}` 기록).

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| A. JobA 1건 + JobB 2건 | **NON-TERMINATING** (JobA 처리 중) | `[decider0:decA, decider1:decB1, decider2:decB2]` |
| B. JobA 0건 + JobB 2건 | **NON-TERMINATING** (JobA 처리 중) | `[decider0:decB1, decider1:decB2]` |
| C. 단일 Job 이 전부 소유(회귀) | `[decider0:d1, decider1:d2, decider2:d3]` | **동일** |
| D. JobA 1건 + JobB 1건(회귀) | `[decider0:d1, decider1:d2]` | **동일** |

현재 정상 동작하는 C·D 는 결과가 완전히 같고(`beanMap` 키로 쓰이는 `decider{인덱스}` 도 동일), A·B 의 무한 루프만 해소됩니다.

## 참고
이 수정으로 `decisionDone` 필드는 값이 증가하기만 하고 더 이상 읽히지 않는 상태가 됩니다. 필드와 증가문까지 함께 정리하는 편이 좋으시면 이 PR 에 반영하겠습니다.