### PR TITLE
fix(bdev.batch): Decision의 Next 행을 편집할 때 발생하는 ArrayIndexOutOfBoundsException 수정

### DIFF
--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/DecisionInfoContentsConstructor.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/DecisionInfoContentsConstructor.java
@@ -569,12 +569,15 @@ public class DecisionInfoContentsConstructor extends InfoContentsConstructor {
 		}
 
 		if (items.length > 0) {
+			int j = 0;
+
 			for (int i = 0; i < items.length; i++) {
 				NextVo nextVo = (NextVo) items[i].getData();
 				if (!isAdd && selectedNextVo.compare(nextVo)) {
 					continue;
 				} else {
-					nextVos[i] = (NextVo) items[i].getData();
+					nextVos[j] = (NextVo) items[i].getData();
+					j++;
 				}
 			}
 		}


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제 (재현)
`DecisionInfoContentsConstructor.getAvailableNextVoFromTable()` 은 편집 모드(선택된 `NextVo` 가 있는 경우)에서 결과 배열을 **`items.length - 1`** 크기로 만들면서, 복사할 때는 **원본 인덱스 `i`** 를 그대로 씁니다.

```java
nextVos = new NextVo[items.length - 1];   // 편집 모드: 선택 행 1개를 뺀 크기
...
for (int i = 0; i < items.length; i++) {
    if (!isAdd && selectedNextVo.compare(nextVo)) {
        continue;                          // 선택 행은 건너뜀
    } else {
        nextVos[i] = (NextVo) items[i].getData();   // 원본 인덱스로 기록
    }
}
```

건너뛴 행이 **마지막 행이 아니면** `i` 가 `items.length - 1` 까지 올라가면서 배열 끝을 넘어 써, **ArrayIndexOutOfBoundsException** 이 발생합니다. Decision 편집 화면의 Next 테이블에서 **마지막이 아닌 행을 선택해 Edit** 하면 재현됩니다.

선택 행이 마지막인 경우에는 인덱스가 배열 크기를 넘지 않아 정상 동작하기 때문에, 이 결함이 지금까지 드러나지 않은 것으로 보입니다.

## 수정 내용
같은 클래스의 `getStepAndDecisionNameList()` 가 동일한 "선택 항목만 제외하고 복사" 처리를 **쓰기 전용 카운터 `j`** 로 올바르게 구현하고 있어, 그 방식에 맞췄습니다.

```diff
 if (items.length > 0) {
+    int j = 0;
+
     for (int i = 0; i < items.length; i++) {
         NextVo nextVo = (NextVo) items[i].getData();
         if (!isAdd && selectedNextVo.compare(nextVo)) {
             continue;
         } else {
-            nextVos[i] = (NextVo) items[i].getData();
+            nextVos[j] = (NextVo) items[i].getData();
+            j++;
         }
     }
 }
```

## 검증 (실측)
해당 메서드의 로직을 그대로 옮긴 standalone 하네스로 수정 전/후를 비교했습니다(`TableItem.getData()` 는 `NextVo[]` 로 대체, 나머지는 동일).

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| 2행 중 **첫 행** 편집 | **AIOOBE** | `[FAILED->step2]` |
| 3행 중 **가운데 행** 편집 | **AIOOBE** | `[COMPLETED->step1, *->step3]` |
| 2행 중 마지막 행 편집(회귀) | `[COMPLETED->step1]` | **동일** |
| 추가 모드(선택 없음, 회귀) | 전체 반환 | **동일** |
| 단일 행 편집(회귀) | `[]` | **동일** |

현재 정상 동작하는 3개 케이스는 결과가 완전히 같고, 예외가 나던 2개 케이스만 정상 반환으로 바뀝니다.