### PR TITLE
로그 어펜더 마법사의 Properties 출력만 org.springframework 레벨이 다른 문제 수정 (Align org.springframework log level in the Properties output of the log appender wizard)

### DIFF
--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/file-properties.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/file-properties.vm
@@ -18,7 +18,7 @@ logger.org-egovframe.additivity = false
 logger.org-egovframe.appenderRef.file0.ref = ${txtAppenderName}
 
 logger.org-springframework.name = org.springframework
-logger.org-springframework.level = INFO
+logger.org-springframework.level = DEBUG
 logger.org-springframework.additivity = false
 logger.org-springframework.appenderRef.file0.ref = ${txtAppenderName}
 

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/rollingFile-properties.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/rollingFile-properties.vm
@@ -23,7 +23,7 @@ logger.org-egovframe.additivity = false
 logger.org-egovframe.appenderRef.rolling_file0.ref = ${txtAppenderName}
 
 logger.org-springframework.name = org.springframework
-logger.org-springframework.level = INFO
+logger.org-springframework.level = DEBUG
 logger.org-springframework.additivity = false
 logger.org-springframework.appenderRef.rolling_file0.ref = ${txtAppenderName}
 

--- a/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/file-properties.vm
+++ b/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/file-properties.vm
@@ -18,7 +18,7 @@ logger.org-egovframe.additivity = false
 logger.org-egovframe.appenderRef.file0.ref = ${txtAppenderName}
 
 logger.org-springframework.name = org.springframework
-logger.org-springframework.level = INFO
+logger.org-springframework.level = DEBUG
 logger.org-springframework.additivity = false
 logger.org-springframework.appenderRef.file0.ref = ${txtAppenderName}
 

--- a/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/rollingFile-properties.vm
+++ b/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/rollingFile-properties.vm
@@ -23,7 +23,7 @@ logger.org-egovframe.additivity = false
 logger.org-egovframe.appenderRef.rolling_file0.ref = ${txtAppenderName}
 
 logger.org-springframework.name = org.springframework
-logger.org-springframework.level = INFO
+logger.org-springframework.level = DEBUG
 logger.org-springframework.additivity = false
 logger.org-springframework.appenderRef.rolling_file0.ref = ${txtAppenderName}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

로그 어펜더 마법사는 같은 입력으로 XML·YAML·Properties 세 형식을 냅니다. 그런데 파일 어펜더와 롤링 파일 어펜더에서 Properties 를 고르면 `org.springframework` 만 `INFO` 로 내려갑니다.

`logging/` 의 15개 템플릿을 전부 대조한 결과입니다.

| 어펜더 | `.vm` (XML) | `-yaml.vm` | `-properties.vm` |
| --- | --- | --- | --- |
| console | DEBUG | DEBUG | DEBUG |
| file | DEBUG | DEBUG | **INFO** |
| rollingFile | DEBUG | DEBUG | **INFO** |
| timeBasedRollingFile | DEBUG | DEBUG | DEBUG |
| jdbc | DEBUG | DEBUG | (해당 없음) |

Properties 형식의 관례는 아닙니다. 같은 형식인 `console-properties.vm` 과 `timeBasedRollingFile-properties.vm` 이 `DEBUG` 입니다. 마법사가 받는 항목도 `txtAppenderName`·`txtLogFileName`·`cboAppend`·`txtConversionPattern` 뿐이라 사용자가 형식별로 레벨을 정할 방법이 없습니다.

같은 파일 안의 다른 로거는 이미 세 형식이 일치합니다. `egovframework` 와 `org.egovframe` 는 셋 다 `DEBUG`, 루트는 셋 다 `INFO` 입니다. 어긋나는 줄은 파일당 하나입니다.

```
# file-properties.vm
 logger.egovframework.level = DEBUG
 logger.org-egovframe.level = DEBUG
-logger.org-springframework.level = INFO
+logger.org-springframework.level = DEBUG
 rootLogger.level = INFO
```

`egovframework.dev.imp.templates` 에 같은 템플릿이 한 벌 더 있고 두 사본은 바이트 단위로 같습니다. 한쪽만 고치면 사본이 갈라지므로 네 파일을 함께 고쳤습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`TemplateCodeGenTest` 가 참조하는 로깅 템플릿은 XML `.vm` 뿐이라 이번 변경과 겹치지 않습니다. 확인은 템플릿 15개의 레벨을 뽑아 대조하는 방식으로 했고, 수정 뒤 `-properties.vm` 에 남은 `INFO` 는 없습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 변경이 아니라 생성되는 설정 파일의 내용 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전후로 생성물에서 달라지는 줄은 위 코드 블록의 한 줄입니다.
