### PR TITLE
콘솔 어펜더 마법사가 입력한 어펜더 이름의 점을 하이픈으로 바꾸는 문제 수정 (Stop rewriting the user-entered appender name in the console appender wizard)

### DIFF
--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/console-properties.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/logging/console-properties.vm
@@ -1,5 +1,3 @@
-#set($txtAppenderName = $txtAppenderName.replace(".", "-"))
-
 # Appender Configuration
 appender.console0.type = Console
 appender.console0.name = ${txtAppenderName}

--- a/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/console-properties.vm
+++ b/egovframework.dev.imp.templates/src/main/resources/eGovFrameTemplates/logging/console-properties.vm
@@ -1,5 +1,3 @@
-#set($txtAppenderName = $txtAppenderName.replace(".", "-"))
-
 # Appender Configuration
 appender.console0.type = Console
 appender.console0.name = ${txtAppenderName}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

콘솔 어펜더 마법사에서 어펜더 이름에 점을 넣으면 생성물에는 하이픈으로 바뀌어 나옵니다. `my.console` 로 입력하면 `my-console` 이 됩니다.

`console-properties.vm` 첫 줄이 값을 치환합니다.

```
#set($txtAppenderName = $txtAppenderName.replace(".", "-"))
```

`logging/` 의 템플릿 15개 중 `#set` 이 있는 파일은 이 하나뿐입니다. 같은 마법사가 내는 `console.vm`(XML)·`console-yaml.vm` 은 물론이고, 같은 Properties 형식인 `file-properties.vm`·`rollingFile-properties.vm`·`timeBasedRollingFile-properties.vm` 도 입력을 그대로 씁니다. 마법사 항목 이름은 "Appender Name" 뿐이라 값이 바뀐다는 안내도 없습니다.

log4j2 제약 때문은 아닙니다. 이 변수는 값 자리에만 들어가고 키 자리에는 쓰이지 않습니다.

```
appender.console0.name = ${txtAppenderName}
logger.egovframework.appenderRef.console0.ref = ${txtAppenderName}
rootLogger.appenderRef.console0.ref = ${txtAppenderName}
```

어펜더를 구분하는 키는 `console0` 로 고정돼 있습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

같은 모양의 설정을 log4j2 2.25.5 로 직접 올려 확인했습니다. 이름에 점이 있어도 어펜더가 그대로 등록되고 로거가 해석됩니다.

```
appender.file0.name = my.console
logger.org-springframework.appenderRef.file0.ref = my.console

$ java Probe
DOTTED-NAME-WORKS
설정된 어펜더: [my.console]
org.springframework 레벨: DEBUG
```

`TemplateCodeGenTest` 가 참조하는 로깅 템플릿은 XML `.vm` 뿐이라 이번 변경과 겹치지 않습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 변경이 아니라 생성되는 설정 파일의 내용 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전후로 달라지는 것은 위 실행 출력의 어펜더 이름 한 값입니다.
