### PR TITLE
fix(dbio): content type 조상 탐색 분기가 뒤바뀌어 실행되지 않던 문제 수정

### DIFF
--- a/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/util/FileUtil.java
+++ b/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/util/FileUtil.java
@@ -121,9 +121,9 @@ public class FileUtil {
 			if(contentType != null) {
 				baseType = contentType.getBaseType();
 				if (baseType != null) {
-					return false;
-				} else {
 					return matchContentType(baseType, id);
+				} else {
+					return false;
 				}
 			} else {
 				return false;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`FileUtil.matchContentType`은 content type을 조상 쪽으로 거슬러 올라가며 id를 대조하도록 쓰여 있는데, 두 분기가 서로 바뀌어 있습니다.

```java
// FileUtil.java:122
baseType = contentType.getBaseType();
if (baseType != null) {
    return false;                            // 조상이 있으면 여기서 끝난다
} else {
    return matchContentType(baseType, id);   // 이 줄은 baseType 이 null 일 때만 닿는다
}
```

재귀 호출은 `baseType != null`이 거짓인 가지 안에 있어서 **항상 `matchContentType(null, id)`로 불립니다.** 그 호출은 `contentType != null` 검사에 걸려 `false`를 돌려줍니다. 즉 조상 탐색은 어느 쪽으로도 일어나지 않고, 이 메서드는 id가 정확히 같을 때만 `true`가 됩니다.

`plugin.xml`이 선언한 content type 넷은 모두 `base-type="org.eclipse.core.runtime.xml"`이라, 이 메서드에 조상 id를 물으면 대조 없이 `false`가 나옵니다.

AS-IS / TO-BE

```diff
 				if (baseType != null) {
-					return false;
-				} else {
 					return matchContentType(baseType, id);
+				} else {
+					return false;
 				}
```

`isSqlMapFile`·`isMapperFile`·`isEGovSqlMapperFile` 셋이 이 메서드를 씁니다. 세 곳 모두 자기 id를 정확히 대조하는 경로라 지금 동작은 바뀌지 않고, 조상 id로 물었을 때만 결과가 달라집니다.

`egovframework.dev.imp.codegen.model`의 `FileUtil`에도 같은 모양이 있지만 그쪽은 호출자가 없어 이번 변경에 넣지 않았습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`plugin.xml`의 선언대로 `sqlMap → xml → text` 계층을 세우고, 수정 전후의 `FileUtil`을 각각 컴파일해 같은 입력으로 불러 봤습니다.

수정 전

```
자기 id 정확히 일치              기대=true   실제=true
조상 id (xml) 로 물어봄          기대=true   실제=false  <-- 어긋남
파생 타입에게 조상 id 로 물어봄   기대=true   실제=false  <-- 어긋남
무관한 id                       기대=false  실제=false
```

수정 후

```
자기 id 정확히 일치              기대=true   실제=true
조상 id (xml) 로 물어봄          기대=true   실제=true
파생 타입에게 조상 id 로 물어봄   기대=true   실제=true
무관한 id                       기대=false  실제=false
```

첫 줄과 마지막 줄이 그대로인 것이 지금 쓰이는 경로가 안 바뀐다는 확인입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

이클립스 플러그인이라 브라우저로 확인할 대상이 아닙니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.
