### PR TITLE
fix: PomParser의 XML 외부 엔티티(XXE) 취약점 수정

### DIFF
--- a/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/parser/PomParser.java
+++ b/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/parser/PomParser.java
@@ -18,6 +18,7 @@ package egovframework.rte.rdt.pom.parser;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.StringReader;
 
 import org.jdom.Document;
 import org.jdom.Element;
@@ -25,6 +26,8 @@ import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.XMLOutputter;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
 
 import egovframework.rte.rdt.pom.exception.PomException;
 import egovframework.rte.rdt.pom.unit.DetailPom;
@@ -45,6 +48,15 @@ public class PomParser {
 		DetailPom pom = null;
 
 		SAXBuilder builder = new SAXBuilder();
+		// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+		// 외부 엔티티·외부 DTD를 읽지 않도록 하며, 내부 엔티티 치환은 기존과 동일하게 동작한다.
+		builder.setEntityResolver(new EntityResolver() {
+			public InputSource resolveEntity(String publicId, String systemId) {
+				return new InputSource(new StringReader(""));
+			}
+		});
+		builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
 		try {
 			Document doc = builder.build(file);


### PR DESCRIPTION
## 문제

`PomParser.parse(File)` 는 사용자 workspace 의 `pom.xml` 을 JDOM `SAXBuilder` 로 파싱하면서 외부 엔티티 처리를 제한하지 않습니다. 오염된 `pom.xml` 을 가진 프로젝트를 IDE 로 열면 XXE(CWE-611) 로 로컬 파일 읽기·SSRF 가 가능합니다.

#138 리뷰에서 @swanpark8538 님이 알려주신 동일 유형의 미방어 파서 중 하나이며, 요청하신 대로 개별 PR 로 분리했습니다.

## 변경

- 외부 엔티티·외부 DTD 요청을 빈 스트림으로 처리하는 `EntityResolver` 설정
- `external-parameter-entities`, `nonvalidating/load-external-dtd` 비활성화

## JDOM 특이사항 (실측)

DOM 계열과 달리 `SAXBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false)` 는 **효과가 없습니다.** JDOM 1.1.1 의 SAXBuilder 가 파서를 구성할 때 이 feature 를 `expandEntities` 값(기본 true)으로 덮어쓰기 때문입니다. 그래서 `EntityResolver` 로 차단했습니다.

| 설정 | 정상 pom | 내부 엔티티 pom | XXE pom |
| --- | --- | --- | --- |
| 현재 코드 | 0.0.1-SNAPSHOT | 9.9.9-ENT | `secret-file-content` (유출) |
| external-general-entities=false 만 적용 | 0.0.1-SNAPSHOT | 9.9.9-ENT | `secret-file-content` (차단 실패) |
| disallow-doctype-decl=true | 0.0.1-SNAPSHOT | **파싱 실패** | 파싱 실패 |
| 본 PR | 0.0.1-SNAPSHOT | 9.9.9-ENT | 빈 값 (차단) |

## 검증

`egovframework.rte.rdt` 의 pom 패키지를 `lib/jdom.jar`(1.1.1) 와 함께 컴파일하고, 변경 전/후 `PomParser.parse()` 를 실제 pom.xml 3종으로 실행해 비교했습니다.

- 정상 pom(리포지터리 내 실제 파일): groupId·version·dependencies 3건 모두 기존과 동일
- 내부 엔티티 pom(`<!ENTITY egovVer "9.9.9-ENT">`): version 이 `9.9.9-ENT` 로 기존과 동일하게 치환 — #138 리뷰에서 지적해 주신 `setExpandEntityReferences(false)` 류의 부작용은 없습니다
- XXE pom(`<!ENTITY xxe SYSTEM "file:///...">`): 기존 `secret-file-content` → 변경 후 빈 값

## 참고

원본 파일 끝에 개행이 없어 GitHub 웹 편집기가 저장하면서 EOF 개행 1줄을 자동으로 추가했습니다(diff 의 `\ No newline at end of file` 항목). 코드 변경은 아닙니다.

관련: #138