### PR TITLE
fix: QueryIdSearchJob의 XML 외부 엔티티(XXE) 취약점 수정

### DIFF
--- a/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/search/QueryIdSearchJob.java
+++ b/egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/search/QueryIdSearchJob.java
@@ -248,6 +248,11 @@ public class QueryIdSearchJob extends Job {
 						InputStream stream = file.getContents();						
 						DocumentBuilderFactory fact = DocumentBuilderFactory.newInstance();
 						fact.setValidating(false);
+						// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+						fact.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+						fact.setFeature("http://xml.org/sax/features/external-general-entities", false);
+						fact.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+						fact.setXIncludeAware(false);
 						DocumentBuilder builder = fact.newDocumentBuilder();
 						builder.setEntityResolver(new EntityResolver() {
 							  @Override


### PR DESCRIPTION
## 문제

`QueryIdSearchJob` 은 워크스페이스의 `.xml` 파일을 `DocumentBuilderFactory` 로 파싱하면서 외부 엔티티 처리를 제한하지 않습니다. 기존 `EntityResolver` 는 iBATIS.com DTD 만 빈 스트림으로 처리하고 그 외에는 `null` 을 반환하므로, 나머지 외부 참조는 파서 기본 동작대로 해석됩니다. 오염된 XML 이 워크스페이스에 있으면 쿼리 ID 검색 과정에서 XXE(CWE-611) 로 로컬 파일 읽기·SSRF 가 가능합니다.

#138 리뷰에서 @swanpark8538 님이 알려주신 동일 유형의 미방어 파서 중 하나이며, 요청하신 대로 개별 PR 로 분리했습니다.

## 변경

외부 엔티티·외부 DTD 로딩을 차단하는 설정 4줄을 추가했습니다. 기존 `setValidating(false)` 와 iBATIS DTD 용 `EntityResolver` 는 그대로 두었습니다.

## 검증 (실측)

리포지터리에 있는 실제 MyBatis 매퍼(`EgovArticleScrap_SQL_cubrid.xml`, DOCTYPE 이 `http://mybatis.org/dtd/mybatis-3-mapper.dtd` 를 가리킴)를 변경 전/후 동일한 코드 경로로 파싱해 비교했습니다.

| | 루트 엘리먼트 | select 개수 | 직렬화 결과 | 파싱 시간 |
| --- | --- | --- | --- | --- |
| 변경 전 | mapper | 3 | 3,514자 | 235ms |
| 변경 후 | mapper | 3 | 3,514자 (완전 동일) | 10ms |

- 파싱 결과는 문자열까지 동일하며, 외부 DTD 를 더 이상 내려받지 않아 오프라인 환경에서도 지연이 없습니다.
- XXE 픽스처(`<!ENTITY xxe SYSTEM "file:///...">`)에서는 변경 전 파일 내용이 그대로 노출되던 것이 변경 후 차단됩니다.
- 내부 엔티티(`<!ENTITY ver "4.3.0">`) 치환은 변경 전후 동일하게 동작합니다 — #138 리뷰에서 지적해 주신 `setExpandEntityReferences(false)` 류의 부작용은 없습니다.

관련: #138