### PR TITLE
fix: ComResourceUtils의 XML 외부 엔티티(XXE) 취약점 수정

### DIFF
--- a/egovframework.dev.imp.commngt/src/egovframework/dev/imp/commngt/util/ComResourceUtils.java
+++ b/egovframework.dev.imp.commngt/src/egovframework/dev/imp/commngt/util/ComResourceUtils.java
@@ -181,6 +181,11 @@ public class ComResourceUtils{
     	try {
 
     		DocumentBuilderFactory docBF = DocumentBuilderFactory.newInstance();
+    		// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+    		docBF.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    		docBF.setXIncludeAware(false);
     		DocumentBuilder docBuilder = (DocumentBuilder) docBF.newDocumentBuilder();
     		
     		// AS-IS 시스템의 document
@@ -246,6 +251,11 @@ public class ComResourceUtils{
     	try {
 
     		DocumentBuilderFactory docBF = DocumentBuilderFactory.newInstance();
+    		// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+    		docBF.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    		docBF.setXIncludeAware(false);
     		DocumentBuilder docBuilder = (DocumentBuilder) docBF.newDocumentBuilder();
     		
     		// AS-IS 시스템의 document

--- a/egovframework.mdev.imp.commngt/src/egovframework/mdev/imp/commngt/util/ComResourceUtils.java
+++ b/egovframework.mdev.imp.commngt/src/egovframework/mdev/imp/commngt/util/ComResourceUtils.java
@@ -180,6 +180,11 @@ public class ComResourceUtils{
     	try {
 
     		DocumentBuilderFactory docBF = DocumentBuilderFactory.newInstance();
+    		// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+    		docBF.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    		docBF.setXIncludeAware(false);
     		DocumentBuilder docBuilder = (DocumentBuilder) docBF.newDocumentBuilder();
     		
     		// AS-IS 시스템의 document
@@ -245,6 +250,11 @@ public class ComResourceUtils{
     	try {
 
     		DocumentBuilderFactory docBF = DocumentBuilderFactory.newInstance();
+    		// XXE(XML External Entity Injection, CWE-611) 취약점 방지
+    		docBF.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    		docBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    		docBF.setXIncludeAware(false);
     		DocumentBuilder docBuilder = (DocumentBuilder) docBF.newDocumentBuilder();
     		
     		// AS-IS 시스템의 document


### PR DESCRIPTION
## 문제

`ComResourceUtils` 의 `checkOldWebXml()`(183행 부근)과 `modifyWebXml()`(248행 부근)은 사용자 프로젝트의 `web.xml` 을 아무 설정 없는 `DocumentBuilderFactory` 로 파싱합니다. 오염된 `web.xml` 이 있으면 XXE(CWE-611) 로 로컬 파일 읽기·SSRF 가 가능합니다.

같은 파일의 `makeDocument()` 는 이미 동일한 차단 설정을 가지고 있어, 이 두 메서드만 분방어 상태입니다. #138 리뷰에서 @swanpark8538 님이 알려주신 항목이며, 요청하신 대로 개별 PR 로 분리했습니다.

## 변경

`dev` / `mdev` 두 미러 파일의 해당 2개소(총 4개소)에 외부 엔티티·외부 DTD 차단 설정을 추가했습니다. 같은 파일 `makeDocument()` 가 이미 쓰는 설정과 동일한 목록이며, 파싱 의미를 바꾸는 `setValidating`·`setNamespaceAware` 는 건드리지 않았습니다.

## 검증 (실측)

서블릿 DTD 를 외부 참조하는 전형적인 web.xml 2.3 문서로 변경 전/후를 비교했습니다.

| | 루트 | servlet | servlet-mapping | 파싱 시간 |
| --- | --- | --- | --- | --- |
| 변경 전 | web-app | 1 | 1 | 169ms |
| 변경 후 | web-app | 1 | 1 | 2ms |

- `checkServletMapping()` 이 사용하는 노드 구조는 동일하며, 외부 DTD 를 내려받지 않아 오프라인 환경에서의 지연도 사라집니다.
- XXE 픽스처(`<!ENTITY xxe SYSTEM "file:///...">`): 변경 전에는 파일 내용이 그대로 치환되었고, 변경 후에는 치환되지 않습니다.
- 내부 엔티티(`<!ENTITY ver "4.3.0">`)는 변경 전후 모두 Text 노드로 동일하게 치환됩니다 — #138 리뷰에서 지적해 주신 `setExpandEntityReferences(false)` 류의 부작용은 없습니다.

관련: #138