### PR TITLE
chore: NexusPropertyPage의 DocumentBuilderFactory 외부 엔티티 차단

### DIFF
--- a/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/properties/NexusPropertyPage.java
+++ b/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/properties/NexusPropertyPage.java
@@ -408,6 +408,11 @@ public class NexusPropertyPage extends PropertyPage implements
 				}else{
 					//dependencies 바로 앞에 repositories 위치
 				    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+				    // XXE(XML External Entity Injection, CWE-611) 취약점 방지
+				    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+				    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+				    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+				    factory.setXIncludeAware(false);
 				    DocumentBuilder builder = factory.newDocumentBuilder();
 				    Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));
 				    Node node = doc.getDocumentElement();


### PR DESCRIPTION
#138 리뷰에서 @swanpark8538 님이 알려주신 미방어 파서 4번째 항목입니다.

## 먼저 밝혀둘 점

이 자리(410행)의 파싱 대상은 **바로 윗줄에서 생성된 고정 문자열**입니다.

```java
String xmlStr = "<repositories>\n\t</repositories>";
...
Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));
```

외부 입력이 닿지 않으므로 **실제 XXE 공격 경로는 없습니다.** 사용자 pom.xml 을 읽는 경로는 같은 메서드 앞부분의 `XmlUtil.getRootNode()` 이며, 그쪽은 #138 에서 이미 차단되었습니다.

## 그래도 넣는 이유

- 정적 분석 도구가 설정 없는 `DocumentBuilderFactory` 를 일괄적으로 검출하므로, 파일 간 방어 수준을 맞춰두면 이후 검토 비용이 줄어듭니다.
- 나중에 `xmlStr` 이 사용자 입력을 포함하도록 바뀜 경우에 대한 안전장치가 됩니다.

불필요하다고 판단하시면 닫아도 괜찮습니다. 다만 같은 유형 4건을 모두 올려달라고 하셔서 사실 관계를 붙여 개별 PR 로 올립니다.

## 회귀 확인

`<repositories>` 문자열 파싱 결과의 노드 구조는 변경 전후 동일하며, DOCTYPE 이 없는 문서이므로 추가한 설정은 파싱 결과에 영향을 주지 않습니다.

관련: #138