### PR TITLE
fix(bdev): job, step TableViewer 가로 채우기, Wizard(page) height 변경

### DIFF
--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/BatchJobCreationCustomizePage.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/pages/BatchJobCreationCustomizePage.java
@@ -215,7 +215,7 @@ public class BatchJobCreationCustomizePage extends WizardPage {
 		BatchTableColumn column = new BatchTableColumn("NO_COLUMN_NAME", 120, SWT.LEFT);
 		column.setColumnToTable(table);
 
-		GridData gData = new GridData(GridData.FILL_VERTICAL);
+		GridData gData = new GridData(GridData.FILL_VERTICAL | GridData.FILL_HORIZONTAL);
 		gData.widthHint = 105;
 
 		tableViewer.getControl().setLayoutData(gData);
@@ -388,7 +388,7 @@ public class BatchJobCreationCustomizePage extends WizardPage {
 	@Override
 	public void setVisible(boolean visible) {
 		if (visible) {
-			Point size = new Point(1150, 1200);
+			Point size = new Point(1150, 1000);
 			getShell().setMinimumSize(size);
 			getShell().setSize(size);
 			batchXMLFileBeanIDList = new BatchXMLFileBeanIDList();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
#### 1. Job, Step TableViewer 가로 채우기
```
GridData gData = new GridData(GridData.FILL_VERTICAL);
==> GridData gData = new GridData(GridData.FILL_VERTICAL | GridData.FILL_HORIZONTAL);
```
#### 2. 타 Wizard 의 최대 height 가 1000 이므로 동일하게 변경(1920 x 1080 해상도에서 아래 버튼 영역 잘림)
```
Point size = new Point(1150, 1200);
==> Point size = new Point(1150, 1000);
```


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
#### 변경 전
<img width="1150" height="1067" alt="BatchJobCreationCustomizePage_asis" src="https://github.com/user-attachments/assets/d2b56bdc-1823-4087-b335-0a12109131ba" />

#### 변경 후
<img width="1147" height="1068" alt="BatchJobCreationCustomizePage_tobe" src="https://github.com/user-attachments/assets/47840d31-458b-4689-974b-de2c7f9f8fc5" />
