### PR TITLE
fix(codegen): Java Config 템플릿 셋이 존재하지 않는 jakarta.sql.DataSource 를 import 하는 문제 수정

### DIFF
--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/sequenceId-java.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/sequenceId-java.vm
@@ -1,6 +1,6 @@
 package ${txtConfigPackage};
 
-import jakarta.sql.DataSource;
+import javax.sql.DataSource;
 
 import org.egovframe.rte.fdl.idgnr.impl.EgovSequenceIdGnrServiceImpl;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/tableId-java.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/tableId-java.vm
@@ -1,6 +1,6 @@
 package ${txtConfigPackage};
 
-import jakarta.sql.DataSource;
+import javax.sql.DataSource;
 
 import org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl;
 import org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl;

--- a/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/transaction-java.vm
+++ b/egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/transaction-java.vm
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import jakarta.sql.DataSource;
+import javax.sql.DataSource;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`eGovFrameTemplates` 정본 트리의 Java Config 템플릿 셋이 `jakarta.sql.DataSource` 를 import 합니다.

```
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/transaction-java.vm:7:import jakarta.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/sequenceId-java.vm:3:import jakarta.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/tableId-java.vm:3:import jakarta.sql.DataSource;
```

`DataSource` 는 Java SE 의 `java.sql` 모듈이 내보내는 `javax.sql` 패키지의 타입입니다. Jakarta EE 가 `javax.*` 를 `jakarta.*` 로 옮길 때 이 패키지는 대상이 아니었으므로 `jakarta.sql` 이라는 패키지는 없습니다. 그래서 이 셋으로 생성한 설정 클래스는 컴파일되지 않습니다.

같은 트리에서 `DataSource` 를 import 하는 나머지 Java Config 템플릿 셋은 `javax.sql.DataSource` 를 씁니다.

```
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/jdbc-java.vm:8:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/c3p0-java.vm:8:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/jpa-java.vm:9:import javax.sql.DataSource;
```

`f0a4568`(eGovframe Plug-Ins v5.0.0) 직전에는 세 템플릿도 `javax.sql.DataSource` 였습니다. 그 커밋이 `jakarta.sql` 로 바꾼 import 는 저장소 전체에서 이 셋뿐입니다.

그 커밋은 `jdbc-java.vm`·`c3p0-java.vm` 도 함께 고쳐 `Spring Framework 6.x, Jakarta EE 9 호환` 주석을 새로 넣으면서도 그 두 파일의 import 는 `javax.sql` 로 두었습니다. Jakarta EE 9 대응에서 이 타입이 `javax.sql` 로 남는다고 같은 커밋이 스스로 적어 둔 셈입니다.

```
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/jdbc-java.vm:8:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/jdbc-java.vm:12: * Spring Framework 6.x, Jakarta EE 9 호환
```

세 템플릿에는 마법사에서 도달합니다. `wizards.xml` 이 세 마법사를 등록하고(`:22` New Datasource Transaction · `:29` New Sequence ID Generation · `:30` New Table ID Generation), 각 마법사의 `Configuration Type` 라디오에서 `Java` 를 고르면 해당 `-java.vm` 을 씁니다. 세 마법사 XML 이 모두 같은 형태이고 아래는 `egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/transaction.xml:95` 입니다.

```xml
<template component="txtClassName" velocity="transaction-java.vm"
    ...
    <condition variable="rdoConfigType" value="Java" />
```

AS-IS

```java
import jakarta.sql.DataSource;
```

TO-BE

```java
import javax.sql.DataSource;
```

### 영향 범위

`Configuration Type` 을 `XML` 로 고르는 경로는 `transaction.vm`·`sequenceId.vm`·`tableId.vm` 을 쓰므로 변화가 없습니다.

`egovframework.dev.imp.templates` 의 사본 여섯은 이미 `javax.sql` 이라 이번 변경에 넣지 않았습니다. 수정 후에는 저장소에 `jakarta.sql` import 가 남지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

번들 매니페스트가 요구하는 JavaSE-21 에서 두 import 를 각각 컴파일했습니다.

```
$ javac J.java   # import jakarta.sql.DataSource;
J.java:1: error: package jakarta.sql does not exist
import jakarta.sql.DataSource;
                  ^
1 error

$ javac V.java   # import javax.sql.DataSource;
(오류 없음)
```

정본 트리의 import 도 대조했습니다.

```
$ git grep -n "import .*sql\.DataSource" -- 'egovframework.dev.imp.codegen.template.templates/*.vm'
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/c3p0-java.vm:8:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/jdbc-java.vm:8:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/sequenceId-java.vm:3:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/idGeneration/tableId-java.vm:3:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/jpa-java.vm:9:import javax.sql.DataSource;
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/transaction/transaction-java.vm:7:import javax.sql.DataSource;
```

수정 전에는 여섯 중 셋이 `jakarta.sql` 이었고 수정 후에는 여섯 모두 `javax.sql` 입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

이클립스 플러그인의 코드 생성 템플릿이라 브라우저 테스트는 하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 위 출력으로 대신합니다.
