### PR TITLE
fix(rte.rdt): 버전 비교가 자리별 수가 아니라 문자열 순서로 이뤄져 업데이트 판정이 뒤집히는 문제 수정

### DIFF
--- a/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/Version.java
+++ b/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/Version.java
@@ -39,6 +39,14 @@ public class Version extends PomString implements Comparable<Version> {
 	 * 프로퍼티가 다른 프로퍼티를 참조하는 연쇄를 따라가는 최대 단계. 순환 참조에서 무한 반복을 막는다.
 	 */
 	private static final int MAX_PROPERTY_DEPTH = 10;
+	/**
+	 * 버전 문자열을 자리(세그먼트)로 나누는 구분자
+	 */
+	private static final String SEGMENT_DELIMITER = "[.\\-_]";
+	/**
+	 * 정식 릴리스와 같은 것으로 취급하는 한정자. 뒤에 붙어도 버전이 낮아지지 않는다.
+	 */
+	private static final String[] RELEASE_QUALIFIERS = { "ga", "final", "release" };
 	
 	/**
 	 * 버전 인스턴스를 생성한다.
@@ -136,11 +144,138 @@ public class Version extends PomString implements Comparable<Version> {
 
 	/**
 	 * 버전간의 비교를 수행한다. 프로퍼티 참조가 아닌 실제 버전을 비교한다.
+	 *
+	 * 버전을 <code>.</code> <code>-</code> <code>_</code> 기준으로 자리별로 나눈 뒤,
+	 * 숫자 자리는 문자열이 아니라 수의 크기로 비교한다. 문자열로만 비교하면
+	 * <code>6.2.9</code> 가 <code>6.2.11</code> 보다 새 버전으로 판정된다.
 	 * @param o 비교할 버전
 	 * @return 비교 결과
 	 */
 	public int compareTo(Version o) {
-		return this.realVersion.compareTo(o.realVersion);
+		return compareVersion(this.realVersion, o.realVersion);
+	}
+
+	/**
+	 * 두 버전 문자열을 자리별로 비교한다.
+	 * @param v1 기준 버전
+	 * @param v2 비교 버전
+	 * @return v1 이 더 낮으면 음수, 같으면 0, 더 높으면 양수
+	 */
+	private static int compareVersion(String v1, String v2) {
+		String[] s1 = v1.split(SEGMENT_DELIMITER);
+		String[] s2 = v2.split(SEGMENT_DELIMITER);
+		int length = Math.max(s1.length, s2.length);
+		for (int i = 0; i < length; i++) {
+			int result = compareSegment(i < s1.length ? s1[i] : null, i < s2.length ? s2[i] : null);
+			if (result != 0) {
+				return result;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * 같은 자리의 두 세그먼트를 비교한다. 한쪽에만 있는 자리는 그 자리의 값이
+	 * 0 이거나 정식 릴리스 한정자이면 없는 것과 같게 보고(4.3 = 4.3.0 = 4.3.Final),
+	 * 그 밖의 숫자면 더 높은 버전으로, SNAPSHOT 같은 한정자면 더 낮은 버전으로 본다.
+	 * @param t1 기준 버전의 세그먼트(없으면 null)
+	 * @param t2 비교 버전의 세그먼트(없으면 null)
+	 * @return t1 이 더 낮으면 음수, 같으면 0, 더 높으면 양수
+	 */
+	private static int compareSegment(String t1, String t2) {
+		if (t1 == null) {
+			return -compareWithAbsent(t2);
+		}
+		if (t2 == null) {
+			return compareWithAbsent(t1);
+		}
+		boolean n1 = isNumeric(t1);
+		boolean n2 = isNumeric(t2);
+		if (n1 && n2) {
+			return compareNumeric(t1, t2);
+		}
+		if (n1 != n2) {
+			// 숫자 자리는 한정자(alpha, RC 등)보다 높은 버전으로 본다.
+			return n1 ? 1 : -1;
+		}
+		boolean r1 = isReleaseQualifier(t1);
+		boolean r2 = isReleaseQualifier(t2);
+		if (r1 != r2) {
+			return r1 ? 1 : -1;
+		}
+		return t1.compareToIgnoreCase(t2);
+	}
+
+	/**
+	 * 상대 버전에는 없는 자리 하나를 비교한다.
+	 * @param t 비교할 세그먼트
+	 * @return 자리가 없는 쪽보다 높으면 양수, 같으면 0, 낮으면 음수
+	 */
+	private static int compareWithAbsent(String t) {
+		if (isNumeric(t)) {
+			return compareNumeric(t, "0");
+		}
+		return isReleaseQualifier(t) ? 0 : -1;
+	}
+
+	/**
+	 * 숫자로만 이루어진 두 세그먼트를 수의 크기로 비교한다. 자릿수가 매우 큰 값도
+	 * 다루기 위해 앞의 0 을 없앤 뒤 길이와 사전순으로 비교한다.
+	 * @param t1 기준 세그먼트
+	 * @param t2 비교 세그먼트
+	 * @return t1 이 작으면 음수, 같으면 0, 크면 양수
+	 */
+	private static int compareNumeric(String t1, String t2) {
+		String d1 = stripLeadingZeros(t1);
+		String d2 = stripLeadingZeros(t2);
+		if (d1.length() != d2.length()) {
+			return d1.length() < d2.length() ? -1 : 1;
+		}
+		return d1.compareTo(d2);
+	}
+
+	/**
+	 * 앞자리의 0 을 제거한다.
+	 * @param s 숫자 문자열
+	 * @return 앞의 0 이 제거된 문자열(모두 0 이면 빈 문자열)
+	 */
+	private static String stripLeadingZeros(String s) {
+		int i = 0;
+		while (i < s.length() && s.charAt(i) == '0') {
+			i++;
+		}
+		return s.substring(i);
+	}
+
+	/**
+	 * 세그먼트가 숫자로만 이루어져 있는지 여부를 가져온다.
+	 * @param s 점검할 세그먼트
+	 * @return 숫자로만 이루어져 있으면 true
+	 */
+	private static boolean isNumeric(String s) {
+		if (s.length() == 0) {
+			return false;
+		}
+		for (int i = 0; i < s.length(); i++) {
+			if (!Character.isDigit(s.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * 세그먼트가 정식 릴리스를 뜻하는 한정자인지 여부를 가져온다.
+	 * @param s 점검할 세그먼트
+	 * @return GA, Final, RELEASE 중 하나이면 true
+	 */
+	private static boolean isReleaseQualifier(String s) {
+		for (int i = 0; i < RELEASE_QUALIFIERS.length; i++) {
+			if (RELEASE_QUALIFIERS[i].equalsIgnoreCase(s)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/egovframework.rte.rdt/src/test/java/egovframework/rte/rdt/pom/unit/VersionTest.java
+++ b/egovframework.rte.rdt/src/test/java/egovframework/rte/rdt/pom/unit/VersionTest.java
@@ -143,7 +143,7 @@ public class VersionTest {
 	}
 
 	@Test
-	public void compareToKeepsLexicalOrderForLiterals() {
+	public void compareToOrdersLiteralVersions() {
 		assertTrue(new Version("4.2.0").compareTo(new Version("4.3.0")) < 0);
 		assertEquals(0, new Version("4.3.0").compareTo(new Version("4.3.0")));
 	}
@@ -157,6 +157,35 @@ public class VersionTest {
 		Version installed = new Version(element("version", "${spring.version}"), properties("spring.version", "4.3.0"));
 		assertFalse(installed.isOlderThan(new Version("4.2.0")));
 		assertTrue(installed.isOlderThan(new Version("4.4.0")));
+	}
+
+	// --- 자리별 수 비교
+
+	@Test
+	public void compareToComparesNumericSegmentsAsNumbers() {
+		assertTrue(new Version("6.2.9").compareTo(new Version("6.2.11")) < 0);
+		assertTrue(new Version("6.2.11").compareTo(new Version("6.2.9")) > 0);
+		assertTrue(new Version("3.9.0").compareTo(new Version("3.10.0")) < 0);
+		assertTrue(new Version("1.9").compareTo(new Version("1.10")) < 0);
+	}
+
+	@Test
+	public void isOlderThanDetectsUpdateOfTwoDigitSegment() {
+		assertTrue(new Version("6.2.9").isOlderThan(new Version("6.2.11")));
+		assertFalse(new Version("6.2.11").isOlderThan(new Version("6.2.9")));
+	}
+
+	@Test
+	public void trailingZeroAndReleaseQualifierDoNotChangeVersion() {
+		assertEquals(0, new Version("4.3").compareTo(new Version("4.3.0")));
+		assertEquals(0, new Version("5.6.15.Final").compareTo(new Version("5.6.15")));
+		assertEquals(0, new Version("4.3.0").compareTo(new Version("4.3.0.GA")));
+	}
+
+	@Test
+	public void snapshotIsOlderThanSameRelease() {
+		assertTrue(new Version("4.3.0-SNAPSHOT").isOlderThan(new Version("4.3.0")));
+		assertFalse(new Version("4.3.0").isOlderThan(new Version("4.3.0-SNAPSHOT")));
 	}
 
 	@Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`Version.compareTo()` 가 `realVersion.compareTo(...)` 로 **문자열 사전순** 비교를 합니다. 버전 자리가 두 자리 이상이 되면 순서가 뒤집힙니다.

```java
public int compareTo(Version o) {
    return this.realVersion.compareTo(o.realVersion);   // "6.2.9" > "6.2.11"
}
```

이 비교는 `Version.isOlderThan()` → `TableList.isOlderThanMaster()` → `TableList.isUpdate(Service)` 로 그대로 이어지므로, RDT 서비스 목록의 **업데이트 가능 여부 판정**이 잘못됩니다.

### 재현 (플러그인이 배포하는 master pom 기준)

`egovframework.rte.rdt/src/main/resources/meta/pom_master.xml` 의 `spring.framework.version` 은 현재 **6.2.11** 입니다.

| 프로젝트 pom(설치) | master pom | 기대 | 현재 결과 |
|---|---|---|---|
| 6.2.9 | 6.2.11 | 업데이트 필요(true) | **false — 업데이트가 목록에 뜨지 않음** |
| 6.2.11 | 6.2.9 | 아님(false) | **true — 다운그레이드를 업데이트로 안내** |
| 3.9.0 | 3.10.0 | true | false |
| 4.3.0-SNAPSHOT | 4.3.0 | true | false |
| 4.3.0 | 4.3.0-SNAPSHOT | false | **true** |

master pom 안의 버전 중 두 자리 이상 자리를 가진 것이 **26개**라 드문 경우가 아닙니다.

### 수정

`compareTo()` 가 버전을 `.` `-` `_` 로 나눈 뒤 **자리별로** 비교하도록 했습니다.

- 숫자 자리끼리는 수의 크기로 비교합니다(`9 < 11`). 앞의 0 을 없앤 뒤 자릿수·사전순으로 비교하므로 자리 값이 커도 넘침이 없습니다.
- 한쪽에만 있는 자리는, 값이 `0` 이거나 정식 릴리스 한정자(`GA`/`Final`/`RELEASE`)면 없는 것과 같게 봅니다. `4.3 = 4.3.0 = 4.3.0.GA`, `5.6.15.Final = 5.6.15`.
- 그 밖의 한정자(`SNAPSHOT`, `alpha`, `RC1` 등)가 뒤에 붙으면 더 낮은 버전으로 봅니다. `4.3.0-SNAPSHOT < 4.3.0`.
- 숫자 자리는 한정자 자리보다 높은 버전으로 봅니다.

`isOlderThan()` 의 기존 방어(버전이 없거나 프로퍼티를 해석하지 못하면 판단 유보)는 그대로 두었고, `compareTo` 의 시그니처와 호출부는 바뀌지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

1. **기존 테스트 전부 통과** — `VersionTest` 15건, `DependencyTest` 5건, `PomObjectTest` 3건, `SecureSAXBuilderTest` 7건이 그대로 통과합니다.
2. **결함 재현 테스트 4건 추가** — 수정 전 코드에서는 4건 모두 실패(`Tests run: 19, Failures: 4`), 수정 후 19건 전부 통과합니다.
3. **Maven 기준 대조** — `pom_master.xml` 에 실제로 들어 있는 버전 **31종**의 모든 조합 **961쌍**을 Maven 의 `org.apache.maven.artifact.versioning.ComparableVersion` 과 대조했고 **불일치 0건** 입니다.

`compareToKeepsLexicalOrderForLiterals` 는 더 이상 사전순이 아니므로 `compareToOrdersLiteralVersions` 로 이름만 바꿨습니다. 단언은 그대로입니다.

### 알려진 한계

위 961쌍 밖에서, 한정자끼리 순서가 갈리는 두 경우는 Maven 과 다르게 판정합니다.

- `2.0.0-M2` vs `2.0-RC1` — 자리 수가 서로 달라 정렬이 어긋납니다.
- `1.0.0.RELEASE` vs `1.0.0` — Maven 은 `RELEASE` 를 릴리스 별칭으로 보지 않아 더 높은 버전으로 판정합니다. 이 플러그인의 용도(설치본이 master 보다 낮은지 판정)에서는 Spring 계열의 `x.y.z.RELEASE` 를 같은 버전으로 보는 편이 안전하다고 판단해 의도적으로 같게 두었습니다.

다르게 보시는 편이 맞다면 알려주시면 맞추겠습니다.

## 테스트 브라우저 Test Browser

- [X] 기타 Others

Eclipse 플러그인(RCP) 코드라 브라우저가 관여하지 않습니다. JDK 21 · JUnit 4.7 로 테스트했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 화면이 아닌 순수 판정 로직이라 스크린샷 대신 테스트 실행 결과로 갈음합니다.

```
수정 전(main) 코드 + 새 테스트
1) compareToComparesNumericSegmentsAsNumbers
2) isOlderThanDetectsUpdateOfTwoDigitSegment
3) trailingZeroAndReleaseQualifierDoNotChangeVersion
4) snapshotIsOlderThanSameRelease
Tests run: 19,  Failures: 4

수정 후
OK (19 tests)
```
