### PR TITLE
fix(rte.rdt): 버전 업데이트가 프로퍼티로 지정된 dependency 의 version 을 실제 값으로 덮어써 모듈 버전이 갈리는 문제 수정

### DIFF
--- a/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/PomObject.java
+++ b/egovframework.rte.rdt/src/main/java/egovframework/rte/rdt/pom/unit/PomObject.java
@@ -30,6 +30,7 @@ import org.jdom.Namespace;
 import org.jdom.Text;
 
 import egovframework.rte.rdt.pom.parser.PomParser;
+import egovframework.rte.rdt.pom.util.StringHelper;
 
 /**
  * 프로젝트에서 사용되는 POM 파일을 모델링한 모델 클래스.
@@ -563,6 +564,14 @@ public class PomObject implements DetailPom {
 	 */
 	public void changeVersion(String dependencyId, Version version) {
 		Dependency dependencyTochange = dependencies.get(dependencyId);
+		Version installedVersion = dependencyTochange.getVersion();
+		// 설치된 버전이 이 pom 의 <properties> 로 지정돼 있으면 <version> 을 실제 값으로 덮어쓰지 않고
+		// 프로퍼티 자체를 고친다. <version> 만 고치면 같은 프로퍼티를 쓰는 다른 dependency 는
+		// 옛 버전으로 남아 한 라이브러리의 모듈들이 서로 다른 버전으로 갈린다.
+		if (installedVersion != null && installedVersion.isPropertyVersion()) {
+			changeProperty(StringHelper.getProperty(installedVersion.getContent()), version.toString());
+			return;
+		}
 		dependencyTochange.getElement().getChild("version", getNamespace()).setText(version.toString());
 		//changeDependency(dependencyTochange);
 	}

--- a/egovframework.rte.rdt/src/test/java/egovframework/rte/rdt/pom/unit/PomObjectTest.java
+++ b/egovframework.rte.rdt/src/test/java/egovframework/rte/rdt/pom/unit/PomObjectTest.java
@@ -19,6 +19,18 @@ public class PomObjectTest {
 	private static final String POM_WITH_PROPERTIES = "<project><modelVersion>4.0.0</modelVersion><artifactId>app</artifactId><version>1.0.0</version>"
 			+ "<properties><spring.version>4.2.0</spring.version></properties></project>";
 
+	private static final String POM_WITH_PROPERTY_VERSIONS = "<project>\n\t<modelVersion>4.0.0</modelVersion>\n\t<artifactId>app</artifactId>\n\t<version>1.0.0</version>\n"
+			+ "\t<properties>\n\t\t<spring.framework.version>6.2.9</spring.framework.version>\n\t</properties>\n"
+			+ "\t<dependencies>\n"
+			+ "\t\t<dependency>\n\t\t\t<groupId>org.springframework</groupId>\n\t\t\t<artifactId>spring-core</artifactId>\n\t\t\t<version>${spring.framework.version}</version>\n\t\t</dependency>\n"
+			+ "\t\t<dependency>\n\t\t\t<groupId>org.springframework</groupId>\n\t\t\t<artifactId>spring-beans</artifactId>\n\t\t\t<version>${spring.framework.version}</version>\n\t\t</dependency>\n"
+			+ "\t</dependencies>\n</project>";
+
+	private static final String POM_WITH_LITERAL_VERSION = "<project>\n\t<modelVersion>4.0.0</modelVersion>\n\t<artifactId>app</artifactId>\n\t<version>1.0.0</version>\n"
+			+ "\t<dependencies>\n"
+			+ "\t\t<dependency>\n\t\t\t<groupId>org.springframework</groupId>\n\t\t\t<artifactId>spring-core</artifactId>\n\t\t\t<version>6.2.9</version>\n\t\t</dependency>\n"
+			+ "\t</dependencies>\n</project>";
+
 	private static final String POM_WITHOUT_PROPERTIES = "<project><modelVersion>4.0.0</modelVersion><artifactId>app</artifactId><version>1.0.0</version></project>";
 
 	private static PomObject parse(String xml) throws Exception {
@@ -47,5 +59,36 @@ public class PomObjectTest {
 		PomObject pom = parse(POM_WITHOUT_PROPERTIES);
 		pom.changeProperty("spring.version", "4.3.0");
 		assertNull(pom.getProperties());
+	}
+
+	// --- 프로퍼티로 지정된 버전의 변경
+
+	@Test
+	public void changeVersionOfPropertyVersionUpdatesPropertyNotVersionElement() throws Exception {
+		PomObject pom = parse(POM_WITH_PROPERTY_VERSIONS);
+		pom.changeVersion("org.springframework.spring-core", new Version("6.2.11"));
+
+		assertEquals("6.2.11", pom.getProperties().getValue("spring.framework.version").toString());
+		assertEquals("${spring.framework.version}",
+				pom.getDependencies().get("org.springframework.spring-core").getElement().getChildText("version"));
+	}
+
+	@Test
+	public void changeVersionOfPropertyVersionKeepsModulesOnTheSameVersion() throws Exception {
+		PomObject pom = parse(POM_WITH_PROPERTY_VERSIONS);
+		pom.changeVersion("org.springframework.spring-core", new Version("6.2.11"));
+
+		assertEquals("${spring.framework.version}",
+				pom.getDependencies().get("org.springframework.spring-beans").getElement().getChildText("version"));
+		assertEquals("6.2.11", pom.getProperties().getValue("spring.framework.version").toString());
+	}
+
+	@Test
+	public void changeVersionOfLiteralVersionUpdatesVersionElement() throws Exception {
+		PomObject pom = parse(POM_WITH_LITERAL_VERSION);
+		pom.changeVersion("org.springframework.spring-core", new Version("6.2.11"));
+
+		assertEquals("6.2.11",
+				pom.getDependencies().get("org.springframework.spring-core").getElement().getChildText("version"));
 	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`PomObject.changeVersion()` 이 dependency 의 `<version>` 엘레멘트를 항상 실제 버전 문자열로 덮어씁니다.

```java
public void changeVersion(String dependencyId, Version version) {
    Dependency dependencyTochange = dependencies.get(dependencyId);
    dependencyTochange.getElement().getChild("version", getNamespace()).setText(version.toString());
}
```

프로젝트 pom 이 `<version>${spring.framework.version}</version>` 처럼 프로퍼티로 버전을 관리하고 있으면, `TableList.InstallDependency()` 의 업데이트 경로에서 **그 dependency 만 값이 박히고 프로퍼티는 옛 버전으로 남습니다.** 같은 프로퍼티를 쓰는 나머지 모듈은 갱신되지 않아, 한 번의 업데이트로 라이브러리 모듈 버전이 서로 갈립니다.

### 재현

프로퍼티로 spring 버전을 관리하는 pom(설치 6.2.9, master 6.2.11)에 현재 코드를 그대로 적용한 결과입니다.

```
### 현재 동작 — pom.changeVersion("6.2.11")
   <spring.framework.version>6.2.9</spring.framework.version>     ← 그대로
   <artifactId>spring-core</artifactId>
   <version>6.2.11</version>                                      ← 값이 박힘
   <artifactId>spring-beans</artifactId>
   <version>${spring.framework.version}</version>                 ← 6.2.9 로 남음
```

업데이트 한 번에 **spring-core 6.2.11 + spring-beans 6.2.9** 로 갈립니다.

### 수정

설치된 버전이 이 pom 의 `<properties>` 로 지정된 것이면 `<version>` 대신 **프로퍼티를 고치도록** 했습니다. 이미 있는 `changeProperty(key, value)` 를 그대로 사용합니다.

```
### 수정 후
   <spring.framework.version>6.2.11</spring.framework.version>    ← 프로퍼티가 갱신됨
   <version>${spring.framework.version}</version>                 ← 표기 유지
   <version>${spring.framework.version}</version>                 ← 같은 버전 유지
```

`Version.isPropertyVersion()` 은 이 pom 의 `<properties>` 에서 값을 찾았을 때만 true 이므로, 부모 pom 의 프로퍼티처럼 이 pom 에서 고칠 수 없는 경우에는 이 경로로 들어오지 않습니다. 버전이 리터럴이면 종전대로 `<version>` 을 고칩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

- 결함 재현 테스트 2건과 리터럴 버전 회귀 테스트 1건을 `PomObjectTest` 에 추가했습니다. 수정 전 코드에서는 재현 테스트 2건이 실패(`Tests run: 6, Failures: 2`), 수정 후 6건 전부 통과합니다.
- 저장소의 기존 테스트도 그대로 통과합니다 — `VersionTest`, `DependencyTest` 5건, `PomObjectTest` 6건, `SecureSAXBuilderTest` 7건.

## 함께 확인하다 발견한 것 (이 PR 범위 밖)

1. `TableList.changeProperty(Version)` 은 같은 목적으로 만들어져 있으나 현재 어디에서도 호출되지 않습니다. 이 수정으로 `changeVersion` 이 프로퍼티까지 다루게 되므로 그 메서드를 정리하는 편이 좋을지 의견 주시면 별도 PR 로 올리겠습니다.
2. `PomObject.assayDependency()` 는 `<dependencies>` 와 첫 `<dependency>` 사이에 공백 텍스트가 있다고 가정합니다(`getContent(indexOf(lastDependency) - 1)`). 줄바꿈 없이 한 줄로 쓰인 pom 에서는 파싱 자체가 `IndexOutOfBoundsException` 으로 실패합니다. 필요하다고 보시면 별도 PR 로 올리겠습니다.

## 테스트 브라우저 Test Browser

- [X] 기타 Others

Eclipse 플러그인(RCP) 코드라 브라우저가 관여하지 않습니다. JDK 21 · JUnit 4.7 로 테스트했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 화면이 아닌 pom 파일 변경 결과라, 실제 pom 을 파싱해 `changeVersion` 을 호출하고 저장한 결과를 위 "재현"·"수정 후" 블록으로 갈음합니다.

```
수정 전(main) PomObject + 새 테스트
1) changeVersionOfPropertyVersionUpdatesPropertyNotVersionElement
2) changeVersionOfPropertyVersionKeepsModulesOnTheSameVersion
Tests run: 6,  Failures: 2

수정 후
OK (6 tests)
```

참고: 같은 판정 경로의 `Version.compareTo` 자리별 비교 수정은 #155 로 따로 올렸습니다. 두 PR 은 파일이 겹치지 않아 서로 독립적으로 적용할 수 있습니다.
