### PR TITLE
fix(bdev.confmngt): Preferences 메뉴 Batch(Parameter, Reader/Writer, Listener), Nexus 설정 Page의 New/Edit 다이얼로그 크기 조정

### DIFF
--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/listeners/ListenerDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/listeners/ListenerDialog.java
@@ -335,9 +335,9 @@ public class ListenerDialog extends StatusDialog {
 	protected Point getInitialSize() {
 		Point point;
 		if (isAddButton) {
-			point = new Point(380, 245);
+			point = new Point(380, 275);
 		} else {
-			point = new Point(380, 225);
+			point = new Point(380, 242);
 		}
 		return point;
 	}

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/parameter/JobParameterDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/parameter/JobParameterDialog.java
@@ -471,7 +471,7 @@ public class JobParameterDialog extends StatusDialog {
 
 	@Override
 	protected Point getInitialSize() {
-		return new Point(380, 265);
+		return new Point(460, 305);
 	}
 
 	@Override

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/JobRWDialog.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/JobRWDialog.java
@@ -460,7 +460,7 @@ public class JobRWDialog extends StatusDialog {
 
 	@Override
 	protected Point getInitialSize() {
-		return new Point(380, 250);
+		return new Point(440, 305);
 	}
 	
 	@Override

--- a/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/preferences/dialog/NexusDialog.java
+++ b/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/preferences/dialog/NexusDialog.java
@@ -100,9 +100,9 @@ public class NexusDialog extends StatusDialog {
 	protected Point getInitialSize() {
 		Point point;
 		if (isAddButton) {
-			point = new Point(550, 350);
+			point = new Point(450, 300);
 		} else {
-			point = new Point(550, 300);
+			point = new Point(450, 270);
 		}
 		return point;
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)
- [x] 기능개선 Enhancements


## 수정된 소스 내용 Modified source
#### 1. Preferences 메뉴 Batch Job/Step/Chunk Listener 설정 Page의 New/Edit 다이얼로그 크기 조정
  - Window > Preferences > eGovFrame > Batch > Listener 설정 Page의 New/Edit 버튼 클릭시 표시되는 다이얼로그의 하단 버튼 부분이 안 보이므로 height를 조정해서 보이도록 변경
  - egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/listeners/ListenerDialog.java
 ```
	protected Point getInitialSize() {
		Point point;
		if (isAddButton) {
			point = new Point(380, 245);
			변경  ==> point = new Point(380, 275);
		} else {
			point = new Point(380, 225);
			변경  ==> point = new Point(380, 242);
		}
		return point;
	}
```

#### 2. Preferences 메뉴 Batch Job Parameter 설정 Page의 New/Edit 다이얼로그 크기 조정
  - Window > Preferences > eGovFrame > Batch > Job Parameter 설정 Page의 New/Edit 버튼 클릭시 표시되는 다이얼로그의 하단 버튼이 안 보이고, Note 부분이 잘려서 width/height를 조정해서 보이도록 변경
  - egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/parameter/JobParameterDialog.java
 ```
	protected Point getInitialSize() {
		return new Point(380, 265);
		변경  ==> return new Point(460, 305);
	}
```

#### 3. Preferences 메뉴 Batch Job Reader/Writer 설정 Page의 New/Edit 다이얼로그 크기 조정
  - Window > Preferences > eGovFrame > Batch > Job Reader/Writer 설정 Page의 New/Edit 버튼 클릭시 표시되는 다이얼로그의 하단 버튼이 안 보이고, Note 부분이 잘려서 width/height를 조정해서 보이도록 변경
  - egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/JobRWDialog.java
 ```
	protected Point getInitialSize() {
		return new Point(380, 250);
		변경  ==> return new Point(440, 305);
	}
```

#### 4. Preferences 메뉴 Nexus 설정 Page의 New/Edit 다이얼로그 크기 조정
  - Window > Preferences > eGovFrame > Nexus 설정 Page의 New/Edit 버튼 클릭시 표시되는 다이얼로그가 Nexus ID 입력, Nexus URL 입력, Release/Snapshot 선택 컨트롤 사이즈 보다 커서 width/height를 줄여 알맞게 보이도록 변경
  - egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/preferences/dialog/NexusDialog.java
 ```
	protected Point getInitialSize() {
		Point point;
		if (isAddButton) {
			point = new Point(550, 350);
			변경  ==> point = new Point(450, 300);
		} else {
			point = new Point(550, 300);
			변경  ==> point = new Point(450, 270);
		}
		return point;
	}
```

## JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
#### 1. Preferences 메뉴 Batch Job/Step/Chunk Listener 설정 Page의 New/Edit 다이얼로그 크기 조정
<img width="847" height="716" alt="image" src="https://github.com/user-attachments/assets/bc49422f-f518-408e-84a9-332dd890845d" />

#### 2. Preferences 메뉴 Batch Job Parameter 설정 Page의 New/Edit 다이얼로그 크기 조정
<img width="1033" height="760" alt="image" src="https://github.com/user-attachments/assets/1947398e-4dcb-4513-8520-af6db9cc1302" />

#### 3. Preferences 메뉴 Batch Job Reader/Writer 설정 Page의 New/Edit 다이얼로그 크기 조정
<img width="966" height="743" alt="image" src="https://github.com/user-attachments/assets/ffff67c4-1fcd-47cd-9d7d-71a991459586" />

#### 4. Preferences 메뉴 Nexus 설정 Page의 New/Edit 다이얼로그 크기 조정
<img width="1057" height="738" alt="image" src="https://github.com/user-attachments/assets/f6c9a7c3-b5b2-4f99-a31b-fb9198febc51" />
