### PR TITLE
fix(dev.confmngt): Preferences 메뉴 Nexus 설정 Page의 Repository 정보(TableViewr) 영역 가로/세로 채우기 설정 및 불필요한 코드 제거

### DIFF
--- a/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/preferences/NexusPreferencePage.java
+++ b/egovframework.dev.imp.confmngt/src/egovframework/dev/imp/confmngt/preferences/NexusPreferencePage.java
@@ -140,15 +140,10 @@ public class NexusPreferencePage extends PreferencePage implements IWorkbenchPre
 	@Override
 	protected Control createContents(Composite composite) {
 		noDefaultAndApplyButton();
-		GridData gData = new GridData(GridData.FILL_BOTH);
-		gData.heightHint = 650;
-		gData.widthHint = 460;
-		GridLayout layout = new GridLayout();
 
 		Composite innerContainer = new Composite(composite, SWT.NONE);
-		GridLayout innerLayout = new GridLayout();
-		innerLayout.numColumns = 2;
-		innerContainer.setLayout(innerLayout);
+		innerContainer.setLayout(new GridLayout(2, false));
+		innerContainer.setLayoutData(new GridData(GridData.FILL_BOTH));
 
 		// Create table
 		tableViewer = new TableViewer(innerContainer,
@@ -156,12 +151,12 @@ public class NexusPreferencePage extends PreferencePage implements IWorkbenchPre
 		Table table = tableViewer.getTable();
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
-		tableViewer.getControl().setLayoutData(gData);
+		tableViewer.getControl().setLayoutData(new GridData(GridData.FILL_BOTH));
 		String[] columnNames = new String[] { ConfMngtMessages.nexusPreferencePageID,
 				ConfMngtMessages.nexusPreferencePageURL, ConfMngtMessages.nexusPreferencePageRELEASE,
 				ConfMngtMessages.nexusPreferencePageSNAPSHOTS };
 
-		int[] columnWidth = new int[] { 70, 250, 73, 75 };
+		int[] columnWidth = new int[] { 70, 250, 73, 90 };
 		int[] columnAlignments = new int[] { SWT.LEFT, SWT.LEFT, SWT.CENTER, SWT.CENTER };
 
 		for (int i = 0; i < columnNames.length; i++) {
@@ -176,7 +171,7 @@ public class NexusPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		Composite buttons = new Composite(innerContainer, SWT.NONE);
 		buttons.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING));
-		layout = new GridLayout();
+		GridLayout layout = new GridLayout();
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		buttons.setLayout(layout);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)
- [x] 기능개선 Enhancements

## 수정된 소스 내용 Modified source
#### 1. 불필요한 GridData(gData) 설정 코드를 제거하고 ..setLayoutData(new GridData(GridData.FILL_BOTH)); 로 간소화
 ```
    GridData gData = new GridData(GridData.FILL_BOTH);
    gData.heightHint = 650;
    gData.widthHint = 460;

    위 코드를 삭제 하고 아래 코드로 간소화

    tableViewer.getControl().setLayoutData(gData);
    변경 ==> tableViewer.getControl().setLayoutData(new GridData(GridData.FILL_BOTH));
```

#### 2. 사용하지 않는 변수 선언 제거 - GridLayout layout = new GridLayout();
```
    GridLayout layout = new GridLayout();
    
    위 불필요한 변수 선언을 제거 하고 필요한 시점에 변수 선언

    layout = new GridLayout();
    변경 ==> GridLayout layout = new GridLayout();
```

#### 3. Repository 정보(TableViewr) 영역을 가로/세로 채우기로 설정해서 Preferences 화면 크기를 마우스로 변경하더라도 채워지도록 수정
 ```
    GridLayout innerLayout = new GridLayout();
    innerLayout.numColumns = 2;
    innerContainer.setLayout(innerLayout);
    
    위 코드를 삭제 하고 아래 코드로 변경

    innerContainer.setLayout(new GridLayout(2, false));
    innerContainer.setLayoutData(new GridData(GridData.FILL_BOTH));
```

#### 4. Repository 정보 TableViewer 의 Snapshots 열 width를 조정해서 처음부터 Snapsh.. 로 잘려 보이는 문제 수정
 ```
    int[] columnWidth = new int[] { 70, 250, 73, 75 };
    변경 ==> int[] columnWidth = new int[] { 70, 250, 73, 90 };
```

## JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
#### 3. Repository 정보(TableViewr) 영역을 가로/세로 채우기로 설정해서 Preferences 화면 크기를 마우스로 변경하더라도 채워지도록 수정
<img width="1253" height="707" alt="image" src="https://github.com/user-attachments/assets/95c83f97-d8f9-4e36-8388-cbe92b44982a" />

#### 4. Repository 정보 TableViewer 의 Snapshots 열 width를 조정해서 처음부터 Snapsh.. 로 잘려 보이는 문제 수정
<img width="1197" height="676" alt="image" src="https://github.com/user-attachments/assets/e8e8a336-3741-4acf-a4c0-24141b5610c5" />
