### PR TITLE
fix(bdev.batch): 배치 마법사가 실행환경에 없는 옛 패키지로 bean 의 class 속성을 생성하는 문제 수정

### DIFF
--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/AppendBatchReaderWriterBeanOperation.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/AppendBatchReaderWriterBeanOperation.java
@@ -217,7 +217,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanLineMapper = new Element("bean");
 			property2.addContent(beanLineMapper);
-			beanLineMapper.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovDefaultLineMapper");
+			beanLineMapper.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper");
 			
 			Element property3 = new Element("property");
 			beanLineMapper.addContent(property3);
@@ -225,7 +225,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanFixedLength = new Element("bean");
 			property3.addContent(beanFixedLength);
-			beanFixedLength.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFixedLengthTokenizer");
+			beanFixedLength.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthTokenizer");
 			
 			Element property4 = new Element("property");
 			beanFixedLength.addContent(property4);
@@ -238,7 +238,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanBeanWrapperFieldSet = new Element("bean");
 			beanfieldSetMapper.addContent(beanBeanWrapperFieldSet);
-			beanBeanWrapperFieldSet.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovObjectMapper");
+			beanBeanWrapperFieldSet.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper");
 			
 			Element beantargetType = new Element("property");
 			beanBeanWrapperFieldSet.addContent(beantargetType);
@@ -270,7 +270,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanLineMapper = new Element("bean");
 			property2.addContent(beanLineMapper);
-			beanLineMapper.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovDefaultLineMapper");
+			beanLineMapper.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper");
 			
 			Element property3 = new Element("property");
 			beanLineMapper.addContent(property3);
@@ -278,7 +278,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanFixedLength = new Element("bean");
 			property3.addContent(beanFixedLength);
-			beanFixedLength.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovDelimitedLineTokenizer");
+			beanFixedLength.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovDelimitedLineTokenizer");
 			
 			Element property4 = new Element("property");
 			beanFixedLength.addContent(property4);
@@ -291,7 +291,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanBeanWrapperFieldSet = new Element("bean");
 			beanfieldSetMapper.addContent(beanBeanWrapperFieldSet);
-			beanBeanWrapperFieldSet.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovObjectMapper");
+			beanBeanWrapperFieldSet.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper");
 			
 			Element beantargetType = new Element("property");
 			beanBeanWrapperFieldSet.addContent(beantargetType);
@@ -446,7 +446,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanDefaultLine = new Element("bean");
 			property3.addContent(beanDefaultLine);
-			beanDefaultLine.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovDefaultLineMapper");
+			beanDefaultLine.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper");
 			
 			Element property4 = new Element("property");
 			beanDefaultLine.addContent(property4);
@@ -454,7 +454,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanFixedLength = new Element("bean");
 			property4.addContent(beanFixedLength);
-			beanFixedLength.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFixedLengthTokenizer");
+			beanFixedLength.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthTokenizer");
 				
 			Element property5 = new Element("property");
 			beanFixedLength.addContent(property5);
@@ -468,7 +468,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanEgovObject = new Element("bean");
 			property7.addContent(beanEgovObject);
-			beanEgovObject.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovObjectMapper");
+			beanEgovObject.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper");
 			
 			Element property8 = new Element("property");
 			beanEgovObject.addContent(property8);
@@ -505,7 +505,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanDefaultLine = new Element("bean");
 			property3.addContent(beanDefaultLine);
-			beanDefaultLine.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovDefaultLineMapper");
+			beanDefaultLine.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper");
 			
 			Element property4 = new Element("property");
 			beanDefaultLine.addContent(property4);
@@ -513,7 +513,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanDelimited = new Element("bean");
 			property4.addContent(beanDelimited);
-			beanDelimited.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovDelimitedLineTokenizer");
+			beanDelimited.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovDelimitedLineTokenizer");
 				
 			Element property5 = new Element("property");
 			beanDelimited.addContent(property5);
@@ -526,7 +526,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanEgovObject = new Element("bean");
 			property7.addContent(beanEgovObject);
-			beanEgovObject.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovObjectMapper");
+			beanEgovObject.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper");
 			
 			Element property8 = new Element("property");
 			beanEgovObject.addContent(property8);
@@ -852,7 +852,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanWrapperField = new Element("bean");
 			property3.addContent(beanWrapperField);
-			beanWrapperField.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFieldExtractor");
+			beanWrapperField.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor");
 			
 			Element property4 = new Element("property");
 			beanWrapperField.addContent(property4);
@@ -884,7 +884,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanDelimitedLine = new Element("bean");
 			property2.addContent(beanDelimitedLine);
-			beanDelimitedLine.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFixedLengthLineAggregator");
+			beanDelimitedLine.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthLineAggregator");
 			
 			Element property3 = new Element("property");
 			beanDelimitedLine.addContent(property3);
@@ -892,7 +892,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanWrapperField = new Element("bean");
 			property3.addContent(beanWrapperField);
-			beanWrapperField.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFieldExtractor");
+			beanWrapperField.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor");
 			
 			Element property4 = new Element("property");
 			beanWrapperField.addContent(property4);
@@ -1050,7 +1050,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanWrapperField= new Element("bean");
 			property5.addContent(beanWrapperField);
-			beanWrapperField.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFieldExtractor");
+			beanWrapperField.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor");
 			
 			Element property6 = new Element("property");
 			beanWrapperField.addContent(property6);
@@ -1093,7 +1093,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanFixedLength = new Element("bean");
 			property4.addContent(beanFixedLength);
-			beanFixedLength.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFixedLengthLineAggregator");
+			beanFixedLength.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthLineAggregator");
 			
 			Element property5 = new Element("property");
 			beanFixedLength.addContent(property5);
@@ -1101,7 +1101,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanWrapperField= new Element("bean");
 			property5.addContent(beanWrapperField);
-			beanWrapperField.setAttribute("class", "egovframework.brte.core.item.file.transform.EgovFieldExtractor");
+			beanWrapperField.setAttribute("class", "org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor");
 			
 			Element property6 = new Element("property");
 			beanWrapperField.addContent(property6);
@@ -1212,7 +1212,7 @@ public class AppendBatchReaderWriterBeanOperation {
 			
 			Element beanFileItemWriter = new Element("bean");
 			property.addContent(beanFileItemWriter);
-			beanFileItemWriter.setAttribute("class", "egovframework.brte.core.item.database.support.EgovMethodMapItemPreparedStatementSetter");
+			beanFileItemWriter.setAttribute("class", "org.egovframe.rte.bat.core.item.database.support.EgovMethodMapItemPreparedStatementSetter");
 						
 			Element property2 = new Element("property");
 			bean.addContent(property2);

--- a/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
+++ b/egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java
@@ -485,7 +485,7 @@ public class CreateBatchJobXMLFileOperation {
 		
 		// create multiple partitioner beans
 		beanMap.put("partitioner" + partitionerType + prefix, partitionName + "<" + partitionerClass + "<" + resource);
-		beanMap.put("fileNameListener" + prefix , prefix + ".fileNameListener" + "<" + "egovframework.brte.core.listener.EgovOutputFileListener" + "<" + resource);
+		beanMap.put("fileNameListener" + prefix , prefix + ".fileNameListener" + "<" + "org.egovframe.rte.bat.core.listener.EgovOutputFileListener" + "<" + resource);
 
 		Element handler = new Element("handler");
 		partition.addContent(handler);
@@ -517,7 +517,7 @@ public class CreateBatchJobXMLFileOperation {
 						decision.setAttribute("id", decisionVOList.get(j).getName());						
 						decision.setAttribute("decider", jobName + "." + decisionVOList.get(j).getName() + "." +"egovDecider");
 						// each decision needs a own decider
-						beanMap.put("decider"+j, jobName + "." + decisionVOList.get(j).getName() + "." +"egovDecider" + "<" + "egovframework.brte.core.job.flow.EgovDecider");
+						beanMap.put("decider"+j, jobName + "." + decisionVOList.get(j).getName() + "." +"egovDecider" + "<" + "org.egovframe.rte.bat.core.job.flow.EgovDecider");
 						
 						// decision next on, to Optional
 						if (decisionVOList.get(j).getNextVo() != null && decisionVOList.get(j).getNextVo().length > 0) {

--- a/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/model/DefaultJobRW.java
+++ b/egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/model/DefaultJobRW.java
@@ -58,7 +58,7 @@ public class DefaultJobRW {
 	final static public String FLAT_FILE_ITEM_WRITER_CLASS = "org.springframework.batch.item.file.FlatFileItemWriter";
 	final static public String IBATIS_BATCH_ITEM_WRITER_CLASS = "org.springframework.batch.item.database.IbatisBatchItemWriter";
 	final static public String JDBC_BATCH_ITEM_WRITER_CLASS = "org.springframework.batch.item.database.JdbcBatchItemWriter";
-	final static public String EGOV_JDBC_BATCH_ITEM_WRITER_CLASS = "egovframework.brte.core.item.database.EgovJdbcBatchItemWriter";
+	final static public String EGOV_JDBC_BATCH_ITEM_WRITER_CLASS = "org.egovframe.rte.bat.core.item.database.EgovJdbcBatchItemWriter";
 	final static public String MULTI_RESOURCE_ITEM_WRITER_CLASS = "org.springframework.batch.item.file.MultiResourceItemWriter";
 
 	


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

배치 마법사가 생성하는 Job 설정 XML 에 `egovframework.brte.…` 로 시작하는 bean 의 class 값이 들어갑니다. 실행환경 저장소에는 그 패키지의 java 파일이 하나도 없습니다.

이 저장소에서:

```
$ git grep -c "egovframework\.brte" origin/main -- "*.java"
origin/main:egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/AppendBatchReaderWriterBeanOperation.java:19
origin/main:egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/jobcreation/operation/CreateBatchJobXMLFileOperation.java:2
origin/main:egovframework.bdev.imp.confmngt/src/egovframework/bdev/imp/confmngt/preferences/readwrite/model/DefaultJobRW.java:1
```

배치 프로젝트 템플릿이 받는 배치 의존성은 `egovframe-rte-bat-core` 이고, 그 아티팩트가 담는 패키지는 `org.egovframe.rte.bat` 입니다. 즉 생성된 프로젝트의 클래스패스에는 새 패키지명만 있고, 이 마법사가 쓴 XML 은 없는 이름을 가리킵니다.

이 저장소에서:

```
$ unzip -p egovframework.bdev.imp.ide/examples/egovframe-boot-batch-db-commandline.zip pom.xml | grep -A2 "egovframe-rte-bat-core"
			<artifactId>egovframe-rte-bat-core</artifactId>
		</dependency>
		<dependency>
```

실행환경 저장소(`eGovFramework/egovframe-runtime`)의 `main` 에서:

```
$ git show origin/main:Batch/org.egovframe.rte.bat.core/pom.xml | grep -m1 "<artifactId>egovframe-rte-bat-core</artifactId>"
    <artifactId>egovframe-rte-bat-core</artifactId>
$ git ls-tree -r --name-only origin/main | grep -c "^Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/"
63
```

같은 플러그인의 Job Launcher 쪽은 이미 새 패키지명으로 옮겨 두었습니다. 남은 22곳은 그때 함께 옮겨지지 않은 자리입니다.

이 저장소에서:

```
$ git show origin/main:egovframework.bdev.imp.batch/src/egovframework/bdev/imp/batch/wizards/joblauncher/operation/CreateBatchJobLauncherXMLFileOperation.java | sed -n "188,189p"
		// 표준프레임워크 v4.0 패키지명 적용
		eGovBatchRunnerBean.setAttribute(new Attribute("class", "org.egovframe.rte.bat.core.launch.support.EgovBatchRunner"));
```

아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)의 `main` 에서 돌린 것입니다.

```
$ git ls-tree -r --name-only origin/main | grep -c "/brte/"
0
$ git ls-tree -r --name-only origin/main | sed "s|.*/java/||;s|/|.|g;s|\.java$||" | grep -E "^org\.egovframe\.rte\.bat\.core\.(item|job|listener)\." | grep -E "EgovDefaultLineMapper$|EgovObjectMapper$|EgovFixedLengthTokenizer$|EgovDelimitedLineTokenizer$|EgovFieldExtractor$|EgovFixedLengthLineAggregator$|EgovMethodMapItemPreparedStatementSetter$|EgovOutputFileListener$|EgovDecider$|EgovJdbcBatchItemWriter$" | sort
org.egovframe.rte.bat.core.item.database.EgovJdbcBatchItemWriter
org.egovframe.rte.bat.core.item.database.support.EgovMethodMapItemPreparedStatementSetter
org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper
org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper
org.egovframe.rte.bat.core.item.file.transform.EgovDelimitedLineTokenizer
org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor
org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthLineAggregator
org.egovframe.rte.bat.core.item.file.transform.EgovFixedLengthTokenizer
org.egovframe.rte.bat.core.job.flow.EgovDecider
org.egovframe.rte.bat.core.listener.EgovOutputFileListener
```

세 파일에서 22곳을 옮겼습니다. 접두어만 `egovframework.brte.` 에서 `org.egovframe.rte.bat.` 으로 바뀌고 나머지 경로와 클래스 이름은 그대로입니다. 이렇게 나온 이름 열 개는 각각 실행환경 저장소에 실재합니다. 위 두 번째 명령이 그 열 개를 찍습니다.

AS-IS

```java
beanLineMapper.setAttribute("class", "egovframework.brte.core.item.file.mapping.EgovDefaultLineMapper");
```

TO-BE

```java
beanLineMapper.setAttribute("class", "org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper");
```

### 영향 범위

세 파일 모두 생성기가 XML 로 내보내는 클래스 이름 문자열만 바뀝니다. 마법사의 화면·입력·분기는 건드리지 않았고, `egovframework.brte.` 접두어를 쓰는 곳은 저장소에 더 남지 않았습니다.
